### PR TITLE
ROSCO Testing

### DIFF
--- a/weis/aeroelasticse/FAST_writer.py
+++ b/weis/aeroelasticse/FAST_writer.py
@@ -1311,6 +1311,7 @@ class InputWriter_OpenFAST(InputWriter_Common):
         controller.Ki_flap              = self.fst_vt['DISCON_in']['Flp_Ki']
         controller.flp_angle            = self.fst_vt['DISCON_in']['Flp_Angle']
         controller.flp_maxpit           = self.fst_vt['DISCON_in']['Flp_MaxPit']
+        controller.Ki_ipc1p             = self.fst_vt['DISCON_in']['IPC_KI'][0]
 
         turbine = type('', (), {})()
         turbine.Cp = type('', (), {})()


### PR DESCRIPTION
We are upgrading the testing of ROSCO in the ROSCO_Toolbox and it now uses the WEIS libraries.  I'll add any required weis/aeroelasticse changes here.  There may be more, so let's keep this open this week, at least.

Minor change: 
1. Since the FAST_Writer needs `controller.Ki_ipc1p` that value must be read from the DISCON file.

