### PR TITLE
Change end of pontoon diameter grid from 0.1 to 1.0

### DIFF
--- a/examples/geometry/nrel5mw-semi_oc4.yaml
+++ b/examples/geometry/nrel5mw-semi_oc4.yaml
@@ -469,7 +469,7 @@ components:
               outer_shape: &pont_out
                 shape: circular
                 outer_diameter:
-                    grid: [0.0, 0.1]
+                    grid: [0.0, 1.0]
                     values: [1.6, 1.6]
               internal_structure: &pont_int
                 layers:


### PR DESCRIPTION
Fix the end point of the grid to 1.0 (it was 0.1) for the pontoon outer diameter. This allows the grid vlaues to extend to the full length of the pontoon.

Of course, if I am wrong, feel free to close the PR!