### PR TITLE
Control Design Variables in Schema

### DIFF
--- a/weis/yaml/analysis_schema_NEW.yaml
+++ b/weis/yaml/analysis_schema_NEW.yaml
@@ -438,24 +438,6 @@ properties:
                 type: object
                 default: {}
                 properties:
-                    pitch:
-                        type: object
-                        default: {}
-                        properties:
-                            pitch_act_bw:
-                                type: object
-                                description: Pitch actutator bandwidth (https://github.com/NREL/ROSCO)
-                                default: {}
-                                properties:
-                                    flag: *flag
-                                    lower_bound: &omega_min
-                                        type: number
-                                        default: 0.0
-                                        unit: rad/s
-                                    upper_bound: &omega_max
-                                        type: number
-                                        default: 100.0
-                                        unit: rad/s
                     generator:
                         type: object
                         default: {}

--- a/weis/yaml/analysis_schema_NEW.yaml
+++ b/weis/yaml/analysis_schema_NEW.yaml
@@ -434,82 +434,421 @@ properties:
                                 properties:
                                     linked: *joint_link
                                     independent: *joint_indep
+            actuators:
+                type: object
+                default: {}
+                properties:
+                    pitch:
+                        type: object
+                        default: {}
+                        properties:
+                            pitch_act_bw:
+                                type: object
+                                description: Pitch controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                default: {}
+                                properties:
+                                    flag: *flag
+                                    lower_bound: &omega_min
+                                        type: number
+                                        default: 0.0
+                                        unit: rad/s
+                                    upper_bound: &omega_max
+                                        type: number
+                                        default: 100.0
+                                        unit: rad/s
+                    generator:
+                        type: object
+                        default: {}
+                        properties:
+                            rated_power:
+                                type: object
+                                description: Pitch controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                default: {}
+                                properties:
+                                    flag: *flag
+                                    lower_bound:
+                                        type: number
+                                        default: 0.0
+                                        unit: MW
+                                    upper_bound:
+                                        type: number
+                                        default: 100.0
+                                        unit: MW
+                            rated_gen_speed:
+                                type: object
+                                description: Pitch controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                default: {}
+                                properties:
+                                    flag: *flag
+                                    lower_bound: 
+                                        type: number
+                                        default: 0.0
+                                        unit: rad/s
+                                    upper_bound:
+                                        type: number
+                                        default: 100000000.0
+                                        unit: rad/s
+                            rated_gen_torque:
+                                type: object
+                                description: Pitch controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                default: {}
+                                properties:
+                                    flag: *flag
+                                    lower_bound: 
+                                        type: number
+                                        default: 0.0
+                                        unit: kNm
+                                    upper_bound:
+                                        type: number
+                                        default: 1000000000000.0
+                                        unit: kNm
             control:
                 type: object
                 default: {}
                 properties:
-                    tsr:
+                    pitch:
+                        type: object
+                        default: {}
+                        properties:
+                            PC_omega: 
+                                type: object
+                                description: Pitch controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                default: {}
+                                properties:
+                                    flag: *flag
+                                    lower_bound: &omega_min
+                                        type: number
+                                        default: 0.0
+                                        unit: rad/s
+                                    upper_bound: &omega_max
+                                        type: number
+                                        default: 100.0
+                                        unit: rad/s
+                            PC_zeta:
+                                type: object
+                                description: Pitch controller desired damping ratio. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                default: {}
+                                properties:
+                                    flag: *flag
+                                    lower_bound: &zeta_min
+                                        type: number
+                                        default: 0.0
+                                        unit: none
+                                    upper_bound: &zeta_max
+                                        type: number
+                                        default: 100.0
+                                        unit: none
+                            ps_percent:
+                                type: object
+                                default: {}
+                                description: Percent peak shaving as a design variable
+                                properties:
+                                    flag: *flag
+                                    lower_bound:
+                                        type: number
+                                        default: 0.0
+                                        unit: none
+                                    upper_bound:
+                                        type: number
+                                        default: 1.0
+                                        unit: none
+                            fl_feedback:
+                                type: object
+                                description: Platform velocity feedback using nacelle IMU
+                                default: {}
+                                properties:
+                                    gain:
+                                        type: object
+                                        default: {}
+                                        description: Gain of floating feedback using nacelle IMU
+                                        properties:
+                                            flag: *flag
+                                            lower_bound:
+                                                type: number
+                                                default: 0.0
+                                                unit: seconds
+                                            upper_bound:
+                                                type: number
+                                                default: 10000
+                                                unit: seconds
+                                    filter:
+                                        type: object
+                                        default: {}
+                                        description: Filter from in platform pitch feedback
+                                        properties:
+                                            flag: *flag
+                            IPC:
+                                type: object
+                                description: Individual pitch control (IPC) using the mulitblade coordinate (MBC) transform
+                                default: {}
+                                properties:
+                                    IPC_gain_1P:
+                                        type: object
+                                        default: {}
+                                        description: Integral gain of 1P feedback
+                                        properties:
+                                            flag: *flag
+                                            lower_bound:
+                                                type: number
+                                                default: 0.0
+                                                unit: rad/Nm
+                                            upper_bound:
+                                                type: number
+                                                default: 10000
+                                                unit: rad/Nm
+                                    IPC_gain_2P:
+                                        type: object
+                                        default: {}
+                                        description: Integral gain of 2P feedback
+                                        properties:
+                                            flag: *flag
+                                            lower_bound:
+                                                type: number
+                                                default: 0.0
+                                                unit: rad/Nm
+                                            upper_bound:
+                                                type: number
+                                                default: 10000
+                                                unit: rad/Nm
+                                    IPC_phase_1P:
+                                        type: object
+                                        default: {}
+                                        description: Phase lag of 1P IPC feedback
+                                        properties:
+                                            flag: *flag
+                                            lower_bound:
+                                                type: number
+                                                default: -3.14
+                                                unit: rad
+                                            upper_bound:
+                                                type: number
+                                                default: 3.14
+                                                unit: rad
+                                    IPC_phase_2P:
+                                        type: object
+                                        default: {}
+                                        description: Phase lag of 2P IPC feedback
+                                        properties:
+                                            flag: *flag
+                                            lower_bound:
+                                                type: number
+                                                default: -3.14
+                                                unit: rad
+                                            upper_bound:
+                                                type: number
+                                                default: 3.14
+                                                unit: rad
+                                    IPC_filt_1P:
+                                        type: object
+                                        default: {}
+                                        description: Filter between tilt/yaw load and tilt/yaw pitch, usually a notch to reduce 3P, 6P frequency.
+                                        properties:
+                                            flag: *flag
+                                    IPC_filt_2P:
+                                        type: object
+                                        default: {}
+                                        description: Filter between tilt/yaw load and tilt/yaw pitch, usually a notch to reduce 3P, 6P frequency.
+                                        properties:
+                                            flag: *flag
+                    torque:
+                        type: object
+                        default: {}
+                        properties:
+                            VS_zeta:
+                                type: object
+                                default: {}
+                                description: Integral gain of 2P feedback
+                                properties:
+                                    flag: *flag
+                                    lower_bound: *zeta_min
+                                    upper_bound: *zeta_max
+                            VS_omega:
+                                type: object
+                                default: {}
+                                description: Integral gain of 2P feedback
+                                properties:
+                                    flag: *flag
+                                    lower_bound: *omega_min
+                                    upper_bound: *omega_max
+                    flap_control:
                         type: object
                         default: {}
                         properties:
                             flag: *flag
-                            min_gain: *mingain
-                            max_gain: *maxgain
-                    ps_percent:
+                            omega_min: *omega_min
+                            omega_max: *omega_max
+                            zeta_min: *zeta_min
+                            zeta_max: *zeta_max
+                    setpoint_smooth:
                         type: object
                         default: {}
-                        description: Percent peak shaving as a design variable
+                        properties:
+                            ss_vsgain:
+                                type: object
+                                default: {}
+                                description: Torque controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                properties:
+                                    flag: *flag
+                                    lower_bound:
+                                        type: number
+                                        default: 0.0
+                                        unit: none
+                                    upper_bound:
+                                        type: number
+                                        default: 10000
+                                        unit: none
+                            ss_pcgain:
+                                type: object
+                                default: {}
+                                description: Pitch controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                properties:
+                                    flag: *flag
+                                    lower_bound:
+                                        type: number
+                                        default: 0.0
+                                        unit: none
+                                    upper_bound:
+                                        type: number
+                                        default: 10000
+                                        unit: none
+                    shutdown:
+                        type: object
+                        default: {}
+                        properties:
+                            limit_value:
+                                type: object
+                                default: {}
+                                description: Turbine shutdown control, when a certain limit (shutdown/limit_type in geometry) is reached
+                                properties:
+                                    flag: *flag
+                                    lower_bound:
+                                        type: number
+                                        default: 0.0
+                                        unit: none
+                                    upper_bound:
+                                        type: number
+                                        default: 10000
+                                        unit: none
+                            pitch_rate:
+                                type: object
+                                default: {}
+                                description: Rate of pitch manuever to max_pitch. Default is 2 deg./s ?
+                                properties:
+                                    flag: *flag
+                                    lower_bound:
+                                        type: number
+                                        default: 0.0
+                                        unit: rad/s
+                                    upper_bound:
+                                        type: number
+                                        default: 10
+                                        unit: rad/s
+                            open_loop_pitch:
+                                type: object
+                                default: {}
+                                description: Pitch controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                properties:
+                                    flag: *flag
+                            open_loop_pwr:
+                                type: object
+                                default: {}
+                                description: Pitch controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                properties:
+                                    flag: *flag
+                    freq_avoidance:
+                        type: object
+                        default: {}
+                        description: Changes generator speed setpoint to avoid turbine natural frequencies. Only single frequency here for now.
+                        properties:
+                            freq:
+                                type: object
+                                default: {}
+                                description: Frequency to avoid
+                                properties:
+                                    flag: *flag
+                                    nopt: *nopt
+                                    lower_bound:
+                                        type: array
+                                        default: [0.0]
+                                        unit: rad/s
+                                    upper_bound:
+                                        type: array
+                                        default: [10000]
+                                        unit: rad/s
+                            avoidance_Param:
+                                type: object
+                                default: {}
+                                description: Buffer speed around frequency to avoid
+                                properties:
+                                    flag: *flag
+                                    nopt: *nopt
+                                    lower_bound:
+                                        type: array
+                                        default: [0.0]
+                                        unit: rad/s
+                                    upper_bound:
+                                        type: array
+                                        default: [0.0]
+                                        unit: rad/s
+                    soft_cut_out:
+                        type: object
+                        default: {}
+                        description: Upper limit of power reference at high wind speeds (lookup table)
+                        properties:
+                            wind_speeds:
+                                type: object
+                                description: List of wind speeds
+                                default: {}
+                                properties:
+                                    flag: *flag
+                                    nopt: *nopt
+                                    lower_bound:
+                                        type: array
+                                        default: [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 50.0]
+                                        unit: m/s
+                                    upper_bound:
+                                        type: array
+                                        default: [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 50.0]
+                                        unit: m/s
+                            power_reference:
+                                type: object
+                                default: {}
+                                description: List of power reference at wind_speeds, number of elements should be same
+                                properties:
+                                    flag: *flag
+                                    nopt: *nopt
+                                    lower_bound:
+                                        type: array
+                                        default: [1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5]
+                                        unit: none
+                                    upper_bound:
+                                        type: array
+                                        default: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+                                        unit: none
+                    user_defined_SS_1:
+                        type: object
+                        default: {}
+                        description: User defined state-space linear controllers within ROSCO
                         properties:
                             flag: *flag
-                            lower_bound:
-                                type: number
-                                default: 0.0
-                                unit: none
-                            upper_bound:
-                                type: number
-                                default: 50.0
-                                unit: none
-                    servo:
+                            n_order: &n_order
+                                type: integer
+                                default: 2
+                                description: Order of SS and TF filter or control
+                    user_defined_TF_1:
                         type: object
                         default: {}
                         properties:
-                            pitch_control:
-                                type: object
-                                default: {}
-                                properties:
-                                    flag: *flag
-                                    omega_min: &omega_min
-                                        type: number
-                                        default: 0.1
-                                        minimum: 0.0
-                                        maximum: 10.0
-                                        unit: none
-                                    omega_max: &omega_max
-                                        type: number
-                                        default: 0.7
-                                        minimum: 0.0
-                                        maximum: 10.0
-                                        unit: none
-                                    zeta_min: &zeta_min
-                                        type: number
-                                        default: 0.4
-                                        minimum: 0.0
-                                        maximum: 10.0
-                                        unit: none
-                                    zeta_max: &zeta_max
-                                        type: number
-                                        default: 1.5
-                                        minimum: 0.0
-                                        maximum: 10.0
-                                        unit: none
-                            torque_control:
-                                type: object
-                                default: {}
-                                properties:
-                                    flag: *flag
-                                    omega_min: *omega_min
-                                    omega_max: *omega_max
-                                    zeta_min: *zeta_min
-                                    zeta_max: *zeta_max
-                            flap_control:
-                                type: object
-                                default: {}
-                                properties:
-                                    flag: *flag
-                                    omega_min: *omega_min
-                                    omega_max: *omega_max
-                                    zeta_min: *zeta_min
-                                    zeta_max: *zeta_max
+                            flag: *flag
+                            n_order: &n_order
+                                type: integer
+                                default: 2
+                                description: Order of SS and TF filter or control
+                    user_defined_OL_1:
+                        type: object
+                        default: {}
+                        properties:
+                            flag: *flag
 
     constraints:
         # GB: These all need gammas or safety factors
@@ -662,6 +1001,32 @@ properties:
                                 minimum: 0.0
                                 maximum: 1.0
                             max: *flapminmax
+                    max_tip_speed:
+                        type: object
+                        description: Words TODO
+                        default: {}
+                        properties:
+                            flag: *flag
+                            min: &tip_minmax
+                                type: number
+                                untis: m/s
+                                default: 100
+                                minimum: 0.0
+                                maximum: 200
+                            max: *tip_minmax
+                    max_gen_speed:
+                        type: object
+                        description: Maximum allowable generator speed
+                        default: {}
+                        properties:
+                            flag: *flag
+                            min: &gen_minmax
+                                type: number
+                                units: rad/s
+                                default: 1.0
+                                minimum: 0.0
+                                maximum: 100000.0
+                            max: *gen_minmax
 
     merit_figure:
         type: string

--- a/weis/yaml/analysis_schema_NEW.yaml
+++ b/weis/yaml/analysis_schema_NEW.yaml
@@ -444,7 +444,7 @@ properties:
                         properties:
                             pitch_act_bw:
                                 type: object
-                                description: Pitch controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                description: Pitch actutator bandwidth (https://github.com/NREL/ROSCO)
                                 default: {}
                                 properties:
                                     flag: *flag
@@ -462,7 +462,7 @@ properties:
                         properties:
                             rated_power:
                                 type: object
-                                description: Pitch controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                description: Generator rated power
                                 default: {}
                                 properties:
                                     flag: *flag
@@ -476,7 +476,7 @@ properties:
                                         unit: MW
                             rated_gen_speed:
                                 type: object
-                                description: Pitch controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                description: Rated generator speed
                                 default: {}
                                 properties:
                                     flag: *flag
@@ -490,7 +490,7 @@ properties:
                                         unit: rad/s
                             rated_gen_torque:
                                 type: object
-                                description: Pitch controller desired natural frequency. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
+                                description: Rated generator torque
                                 default: {}
                                 properties:
                                     flag: *flag
@@ -617,7 +617,7 @@ properties:
                             VS_zeta:
                                 type: object
                                 default: {}
-                                description: Integral gain of 2P feedback
+                                description: Damping ratio of torque control regulator mode
                                 properties:
                                     flag: *flag
                                     lower_bound: *zeta_min
@@ -625,7 +625,7 @@ properties:
                             VS_omega:
                                 type: object
                                 default: {}
-                                description: Integral gain of 2P feedback
+                                description: Natural frequency of torque control regulator mode
                                 properties:
                                     flag: *flag
                                     lower_bound: *omega_min
@@ -639,97 +639,6 @@ properties:
                             omega_max: *omega_max
                             zeta_min: *zeta_min
                             zeta_max: *zeta_max
-                    setpoint_smooth:
-                        type: object
-                        default: {}
-                        properties:
-                            ss_vsgain:
-                                type: object
-                                default: {}
-                                description: Torque controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
-                                properties:
-                                    flag: *flag
-                                    lower_bound:
-                                        type: number
-                                        default: 0.0
-                                        unit: none
-                                    upper_bound:
-                                        type: number
-                                        default: 10000
-                                        unit: none
-                            ss_pcgain:
-                                type: object
-                                default: {}
-                                description: Pitch controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
-                                properties:
-                                    flag: *flag
-                                    lower_bound:
-                                        type: number
-                                        default: 0.0
-                                        unit: none
-                                    upper_bound:
-                                        type: number
-                                        default: 10000
-                                        unit: none
-                    soft_cut_out:
-                        type: object
-                        default: {}
-                        description: Upper limit of power reference at high wind speeds (lookup table)
-                        properties:
-                            wind_speeds:
-                                type: object
-                                description: List of wind speeds
-                                default: {}
-                                properties:
-                                    flag: *flag
-                                    nopt: *nopt
-                                    lower_bound:
-                                        type: array
-                                        default: [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 50.0]
-                                        unit: m/s
-                                    upper_bound:
-                                        type: array
-                                        default: [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 50.0]
-                                        unit: m/s
-                            power_reference:
-                                type: object
-                                default: {}
-                                description: List of power reference at wind_speeds, number of elements should be same
-                                properties:
-                                    flag: *flag
-                                    nopt: *nopt
-                                    lower_bound:
-                                        type: array
-                                        default: [1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5]
-                                        unit: none
-                                    upper_bound:
-                                        type: array
-                                        default: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-                                        unit: none
-                    user_defined_SS_1:
-                        type: object
-                        default: {}
-                        description: User defined state-space linear controllers within ROSCO
-                        properties:
-                            flag: *flag
-                            n_order: &n_order
-                                type: integer
-                                default: 2
-                                description: Order of SS and TF filter or control
-                    user_defined_TF_1:
-                        type: object
-                        default: {}
-                        properties:
-                            flag: *flag
-                            n_order: &n_order
-                                type: integer
-                                default: 2
-                                description: Order of SS and TF filter or control
-                    user_defined_OL_1:
-                        type: object
-                        default: {}
-                        properties:
-                            flag: *flag
 
     constraints:
         # GB: These all need gammas or safety factors
@@ -872,7 +781,7 @@ properties:
                 properties:
                     flap_control:
                         type: object
-                        description: Words TODO
+                        description: Words TODO  # DZ: I'm not sure what this represents
                         default: {}
                         properties:
                             flag: *flag
@@ -884,7 +793,7 @@ properties:
                             max: *flapminmax
                     max_tip_speed:
                         type: object
-                        description: Words TODO
+                        description: Maximum allowable tip speed
                         default: {}
                         properties:
                             flag: *flag

--- a/weis/yaml/analysis_schema_NEW.yaml
+++ b/weis/yaml/analysis_schema_NEW.yaml
@@ -596,20 +596,6 @@ properties:
                                                 type: number
                                                 default: 10000
                                                 unit: rad/Nm
-                                    IPC_gain_2P:
-                                        type: object
-                                        default: {}
-                                        description: Integral gain of 2P feedback
-                                        properties:
-                                            flag: *flag
-                                            lower_bound:
-                                                type: number
-                                                default: 0.0
-                                                unit: rad/Nm
-                                            upper_bound:
-                                                type: number
-                                                default: 10000
-                                                unit: rad/Nm
                                     IPC_phase_1P:
                                         type: object
                                         default: {}
@@ -624,32 +610,6 @@ properties:
                                                 type: number
                                                 default: 3.14
                                                 unit: rad
-                                    IPC_phase_2P:
-                                        type: object
-                                        default: {}
-                                        description: Phase lag of 2P IPC feedback
-                                        properties:
-                                            flag: *flag
-                                            lower_bound:
-                                                type: number
-                                                default: -3.14
-                                                unit: rad
-                                            upper_bound:
-                                                type: number
-                                                default: 3.14
-                                                unit: rad
-                                    IPC_filt_1P:
-                                        type: object
-                                        default: {}
-                                        description: Filter between tilt/yaw load and tilt/yaw pitch, usually a notch to reduce 3P, 6P frequency.
-                                        properties:
-                                            flag: *flag
-                                    IPC_filt_2P:
-                                        type: object
-                                        default: {}
-                                        description: Filter between tilt/yaw load and tilt/yaw pitch, usually a notch to reduce 3P, 6P frequency.
-                                        properties:
-                                            flag: *flag
                     torque:
                         type: object
                         default: {}
@@ -711,85 +671,6 @@ properties:
                                         type: number
                                         default: 10000
                                         unit: none
-                    shutdown:
-                        type: object
-                        default: {}
-                        properties:
-                            limit_value:
-                                type: object
-                                default: {}
-                                description: Turbine shutdown control, when a certain limit (shutdown/limit_type in geometry) is reached
-                                properties:
-                                    flag: *flag
-                                    lower_bound:
-                                        type: number
-                                        default: 0.0
-                                        unit: none
-                                    upper_bound:
-                                        type: number
-                                        default: 10000
-                                        unit: none
-                            pitch_rate:
-                                type: object
-                                default: {}
-                                description: Rate of pitch manuever to max_pitch. Default is 2 deg./s ?
-                                properties:
-                                    flag: *flag
-                                    lower_bound:
-                                        type: number
-                                        default: 0.0
-                                        unit: rad/s
-                                    upper_bound:
-                                        type: number
-                                        default: 10
-                                        unit: rad/s
-                            open_loop_pitch:
-                                type: object
-                                default: {}
-                                description: Pitch controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
-                                properties:
-                                    flag: *flag
-                            open_loop_pwr:
-                                type: object
-                                default: {}
-                                description: Pitch controller setpoint smoother gain bias percentage. It is used by the ROSCO controller (https://github.com/NREL/ROSCO)
-                                properties:
-                                    flag: *flag
-                    freq_avoidance:
-                        type: object
-                        default: {}
-                        description: Changes generator speed setpoint to avoid turbine natural frequencies. Only single frequency here for now.
-                        properties:
-                            freq:
-                                type: object
-                                default: {}
-                                description: Frequency to avoid
-                                properties:
-                                    flag: *flag
-                                    nopt: *nopt
-                                    lower_bound:
-                                        type: array
-                                        default: [0.0]
-                                        unit: rad/s
-                                    upper_bound:
-                                        type: array
-                                        default: [10000]
-                                        unit: rad/s
-                            avoidance_Param:
-                                type: object
-                                default: {}
-                                description: Buffer speed around frequency to avoid
-                                properties:
-                                    flag: *flag
-                                    nopt: *nopt
-                                    lower_bound:
-                                        type: array
-                                        default: [0.0]
-                                        unit: rad/s
-                                    upper_bound:
-                                        type: array
-                                        default: [0.0]
-                                        unit: rad/s
                     soft_cut_out:
                         type: object
                         default: {}

--- a/weis/yaml/geometry_schema.yaml
+++ b/weis/yaml/geometry_schema.yaml
@@ -2209,12 +2209,24 @@ properties:
                 type: object
                 required:
                     - rated_power
+                    - rated_torque
+                    - rated_speed
                     - max_torque_rate
                     - max_gen_speed
                 properties:
                     rated_power:
                         type: number
                         description: Nameplate power of the turbine, i.e. the rated electrical output of the generator.
+                        unit: W
+                        minimum: 0
+                    rated_torque:
+                        type: number
+                        description: Rated generator load torque
+                        unit: W
+                        minimum: 0
+                    rated_speed:
+                        type: number
+                        description: Rated generator speed
                         unit: W
                         minimum: 0
                     max_gen_speed:
@@ -2285,8 +2297,6 @@ properties:
             - power_control
             - freq_avoidance
             - soft_cut_out
-            - user_defined_mods
-            - user_defined_OL
             - user_dylib
             - user_simulink
             - user_defined_SS_1
@@ -2534,6 +2544,7 @@ properties:
                         maximum: 0.2  # Technically, actuators/pitch/max_pitch_rate
                     open_loop_pitch:
                         type: object
+                        description: Pitch trajectory when limit is exceeded
                         required:
                             - time
                             - pitch
@@ -2543,6 +2554,8 @@ properties:
                             pitch:
                                 $ref: "#/definitions/timeseries/value"
                     open_loop_pwr:
+                        type: object
+                        description: Power trajectory when limit is exceeed
                         required:
                             - time
                             - power
@@ -2721,9 +2734,9 @@ properties:
                             minItems: 1
                             uniqueItems: false
 
-            user_defined_SS_1: &uss
+            user_defined_SS_1: &u_ss
                 type: object
-                description: User defined state-space linear controllers within ROSCO, only 1 for now
+                description: User defined state-space linear controllers within ROSCO
                 required:
                     - sensors
                     - actuators
@@ -2749,10 +2762,10 @@ properties:
                         $ref: "#/definitions/state_space"
                     activator:
                         $ref: "#/definitions/activator"
-            user_defined_SS_2: *uss
-            user_defined_SS_3: *uss
-            user_defined_SS_4: *uss
-            user_defined_SS_5: *uss
+            user_defined_SS_2: *u_ss
+            user_defined_SS_3: *u_ss
+            user_defined_SS_4: *u_ss
+            user_defined_SS_5: *u_ss
             user_defined_TF_1: &u_tf
                 type: object
                 description: User defined transfer function linear controllers within ROSCO, only 1 for now


### PR DESCRIPTION
Changes from original control-related analysis schema:
- control now has subfields: pitch, torque, flap_control (previous design variables moved into these subfields)
- added floating feedback and IPC to control design variables
- added actuator field, with only generator for now
- some small updates to control-related parameters in geometry schema
