### PR TITLE
B/no openfast

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,13 @@ The core WEIS modules are:
 
 ## Installation
 
-Installation with [Anaconda](https://www.anaconda.com) is the recommended approach because of the ability to create self-contained environments suitable for testing and analysis.  WEIS requires [Anaconda 64-bit](https://www.anaconda.com/distribution/).
+On laptop and personal computers, installation with [Anaconda](https://www.anaconda.com) is the recommended approach because of the ability to create self-contained environments suitable for testing and analysis.  WEIS requires [Anaconda 64-bit](https://www.anaconda.com/distribution/). 
 
 The installation instructions below use the environment name, "weis-env," but any name is acceptable.
+
+0.  On the DOE HPC system eagle, make sure to start from a clean setup and type
+        module purge
+        module load conda        
 
 1.  Setup and activate the Anaconda environment from a prompt (Anaconda3 Power Shell on Windows or Terminal.app on Mac)
 
@@ -69,8 +73,7 @@ The installation instructions below use the environment name, "weis-env," but an
         git clone https://github.com/WISDEM/WEIS.git
         cd WEIS
         git checkout branch_name # (Only if you want to switch git branch, say develop)
-        module purge
-        module load conda comp-intel intel-mpi mkl
+        module load comp-intel intel-mpi mkl
         module unload gcc
         python setup.py develop
 

--- a/examples/02_control_opt/modeling_options.yaml
+++ b/examples/02_control_opt/modeling_options.yaml
@@ -55,12 +55,6 @@ Level3: # Options for WEIS fidelity level 3 = nonlinear time domain
         flag: True
     
 openfast:
-    analysis_settings:
-        Analysis_Level:     2           # Flag to set the call to OpenFAST. 1 - generate OpenFAST model, 2 - generate and run OpenFAST model
-        update_hub_nacelle: False
-        update_tower:       False
-        generate_af_coords: False
-        debug_level:        2    # Flag to set the debug level, do not change
     file_management:
         FAST_namingOut:    IEA15         # Name of the OpenFAST output files
         FAST_runDirectory: temp/IEA15             # Path to folder with the OpenFAST output files

--- a/examples/03_NREL5MW_OC3_spar/modeling_options.yaml
+++ b/examples/03_NREL5MW_OC3_spar/modeling_options.yaml
@@ -55,12 +55,6 @@ Level3: # Options for WEIS fidelity level 3 = nonlinear time domain
         flag: True
     
 openfast:
-    analysis_settings:
-        Analysis_Level:     2           # Flag to set the call to OpenFAST. 1 - generate OpenFAST model, 2 - generate and run OpenFAST model
-        update_hub_nacelle: False
-        update_tower:       False
-        generate_af_coords: False
-        debug_level:        2    # Flag to set the debug level, do not change
     file_management:
         FAST_namingOut:    NREL5MW_OC3_spar         # Name of the OpenFAST output files
         FAST_runDirectory: temp/NREL5MW_OC3_spar             # Path to folder with the OpenFAST output files

--- a/examples/05_IEA-3.4-130-RWT/modeling_options.yaml
+++ b/examples/05_IEA-3.4-130-RWT/modeling_options.yaml
@@ -53,12 +53,6 @@ Level3: # Options for WEIS fidelity level 3 = nonlinear time domain
         flag: True
     
 openfast:
-    analysis_settings:
-        Analysis_Level:     2           # Flag to set the call to OpenFAST. 1 - generate OpenFAST model, 2 - generate and run OpenFAST model
-        update_hub_nacelle: False
-        update_tower:       False
-        generate_af_coords: False
-        debug_level:        2    # Flag to set the debug level, do not change
     file_management:
         FAST_namingOut:    IEA34         # Name of the OpenFAST output files
         FAST_runDirectory: temp/iea34             # Path to folder with the OpenFAST output files

--- a/examples/06_IEA-15-240-RWT/modeling_options.yaml
+++ b/examples/06_IEA-15-240-RWT/modeling_options.yaml
@@ -61,12 +61,6 @@ Level3: # Options for WEIS fidelity level 3 = nonlinear time domain
         flag: True
     
 openfast:
-    analysis_settings:
-        Analysis_Level:     2           # Flag to set the call to OpenFAST. 1 - generate OpenFAST model, 2 - generate and run OpenFAST model
-        update_hub_nacelle: False
-        update_tower:       False
-        generate_af_coords: False
-        debug_level:        2    # Flag to set the debug level, do not change
     file_management:
         FAST_namingOut:    IEA15         # Name of the OpenFAST output files
         FAST_runDirectory: temp/IEA15             # Path to folder with the OpenFAST output files

--- a/weis/aeroelasticse/CaseGen_IEC.py
+++ b/weis/aeroelasticse/CaseGen_IEC.py
@@ -296,6 +296,7 @@ class CaseGen_IEC():
             case_inputs_i[("InflowWind","WindType")] = {'vals':WindFile_type_out, 'group':1}
             case_inputs_i[("InflowWind","Filename_Uni")] = {'vals':WindFile_out, 'group':1}
             case_inputs_i[("InflowWind","FileName_BTS")] = {'vals':WindFile_out, 'group':1}
+            case_inputs_i[("InflowWind","RefLength")] = {'vals':[self.D], 'group':0}
 
             if len(self.dlc_inputs['Yaw'][i]) > 0:
                     case_inputs_i[("ElastoDyn","NacYaw")] = {'vals':self.dlc_inputs['Yaw'][i], 'group':2}

--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -1023,14 +1023,6 @@ class FASTLoadCases(ExplicitComponent):
                 case_inputs[("ElastoDyn","BlPitch2")]    = case_inputs[("ElastoDyn","BlPitch1")]
                 case_inputs[("ElastoDyn","BlPitch3")]    = case_inputs[("ElastoDyn","BlPitch1")]
 
-                # User defined simulation settings
-                if ("InflowWind","WindType") in case_inputs:
-                    print('WARNING: You have defined ("InflowWind","WindType"} in the openfast settings.'
-                            'This will overwrite the default powercurve settings')
-                if ("InflowWind","HWindSpeed") in case_inputs:
-                    print('WARNING: You have defined ("InflowWind","HWindSpeed"} in the openfast settings.'
-                            'This will overwrite the default powercurve settings')
-
                 case_list, case_name = CaseGen_General(case_inputs, self.FAST_runDirectory, self.FAST_namingOut + '_powercurve')
 
             dlc_list = [0.]*len(case_name)

--- a/weis/aeroelasticse/pyIECWind.py
+++ b/weis/aeroelasticse/pyIECWind.py
@@ -106,6 +106,7 @@ class pyIECWind_extreme():
         shear_vert = np.zeros_like(t)+alpha
         shear_vert_lin = np.zeros_like(t)
         V_gust = np.zeros_like(t)
+        upflow = np.zeros_like(t)
 
         V_gust = min([ 1.35*(V_e1 - V_hub), 3.3*(sigma_1/(1+0.1*(self.D/self.Sigma_1))) ])
 
@@ -120,7 +121,7 @@ class pyIECWind_extreme():
         self.fname_out = []
         self.fname_type = []
         fname = self.case_name + '_EOG_U%2.1f.wnd'%V_hub_in
-        data = np.column_stack((t, V, V_dir, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust_t))
+        data = np.column_stack((t, V, V_dir, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust_t, upflow))
         hd = []
         hd.append('! Extreme operating guest\n')
         hd = self.heading_common(hd)
@@ -155,8 +156,9 @@ class pyIECWind_extreme():
         shear_vert = np.zeros_like(t)+alpha
         shear_vert_lin = np.zeros_like(t)
         V_gust = np.zeros_like(t)
+        upflow = np.zeros_like(t)
 
-        # Transcient
+        # Transient
         Theta_e = 4.*np.arctan(sigma_1/(V_hub*(1.+0.01*(self.D/self.Sigma_1))))*180./np.pi
         if Theta_e > 180.:
             Theta_e = 180.
@@ -177,7 +179,7 @@ class pyIECWind_extreme():
         if self.dir_change.lower() == 'both' or self.dir_change.lower() == '+':
             ## Vert
             fname = self.case_name + '_EDC_P_U%2.1f.wnd'%V_hub_in
-            data = np.column_stack((t, V, Theta_p, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust))
+            data = np.column_stack((t, V, Theta_p, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust, upflow))
             hd = []
             hd.append('! Exteme Vertical Wind Shear, positive\n')
             hd = self.heading_common(hd)
@@ -190,7 +192,7 @@ class pyIECWind_extreme():
         if self.dir_change.lower() == 'both' or self.dir_change.lower() == '-':
             ## Vert
             fname = self.case_name + '_EDC_N_U%2.1f.wnd'%V_hub_in
-            data = np.column_stack((t, V, Theta_n, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust))
+            data = np.column_stack((t, V, Theta_n, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust, upflow))
             hd = []
             hd.append('! Exteme Vertical Wind Shear, negative\n')
             hd = self.heading_common(hd)
@@ -224,8 +226,9 @@ class pyIECWind_extreme():
         shear_vert = np.zeros_like(t)+alpha
         shear_vert_lin = np.zeros_like(t)
         V_gust = np.zeros_like(t)
+        upflow = np.zeros_like(t)
 
-        # Transcient
+        # Transient
         if V_hub < 4:
             Theta_cg = 180
         else:
@@ -250,7 +253,7 @@ class pyIECWind_extreme():
         if self.dir_change.lower() == 'both' or self.dir_change.lower() == '+':
             ## Vert
             fname = self.case_name + '_ECD_P_U%2.1f.wnd'%V_hub_in
-            data = np.column_stack((t, V, Theta_p, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust))
+            data = np.column_stack((t, V, Theta_p, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust, upflow))
             hd = []
             hd.append('! Exteme coherent gust with direction change, positive\n')
             hd = self.heading_common(hd)
@@ -263,7 +266,7 @@ class pyIECWind_extreme():
         if self.dir_change.lower() == 'both' or self.dir_change.lower() == '-':
             ## Vert
             fname = self.case_name + '_ECD_N_U%2.1f.wnd'%V_hub_in
-            data = np.column_stack((t, V, Theta_n, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust))
+            data = np.column_stack((t, V, Theta_n, V_vert, shear_horz, shear_vert, shear_vert_lin, V_gust, upflow))
             hd = []
             hd.append('! Exteme coherent gust with direction change, negative\n')
             hd = self.heading_common(hd)
@@ -297,8 +300,9 @@ class pyIECWind_extreme():
         # shear_horz = np.zeros_like(t)
         shear_vert = np.zeros_like(t)+alpha
         V_gust = np.zeros_like(t)
+        upflow = np.zeros_like(t)
 
-        # Transcient
+        # Transient
         shear_lin_p = np.zeros_like(t)
         shear_lin_n = np.zeros_like(t)
 
@@ -313,7 +317,7 @@ class pyIECWind_extreme():
             if self.shear_orient.lower() == 'both' or self.shear_orient.lower() == 'v':
                 ## Vert
                 fname = self.case_name + '_EWS_V_P_U%2.1f.wnd'%V_hub_in
-                data = np.column_stack((t, V, V_dir, V_vert, np.zeros_like(t), shear_vert, shear_lin_p, V_gust))
+                data = np.column_stack((t, V, V_dir, V_vert, np.zeros_like(t), shear_vert, shear_lin_p, V_gust, upflow))
                 hd = []
                 hd.append('! Exteme Vertical Wind Shear, positive\n')
                 hd = self.heading_common(hd)
@@ -325,7 +329,7 @@ class pyIECWind_extreme():
             if self.shear_orient.lower() == 'both' or self.shear_orient.lower() == 'h':
                 # Horz
                 fname = self.case_name + '_EWS_H_P_U%2.1f.wnd'%V_hub_in
-                data = np.column_stack((t, V, V_dir, V_vert, shear_lin_p, shear_vert, np.zeros_like(t), V_gust))
+                data = np.column_stack((t, V, V_dir, V_vert, shear_lin_p, shear_vert, np.zeros_like(t), V_gust, upflow))
                 hd = []
                 hd.append('! Exteme Horizontal Wind Shear, positive\n')
                 hd = self.heading_common(hd)
@@ -338,7 +342,7 @@ class pyIECWind_extreme():
             if self.shear_orient.lower() == 'both' or self.shear_orient.lower() == 'v':
                 ## Vert
                 fname = self.case_name + '_EWS_V_N_U%2.1f.wnd'%V_hub_in
-                data = np.column_stack((t, V, V_dir, V_vert, np.zeros_like(t), shear_vert, shear_lin_n, V_gust))
+                data = np.column_stack((t, V, V_dir, V_vert, np.zeros_like(t), shear_vert, shear_lin_n, V_gust, upflow))
                 hd = []
                 hd.append('! Exteme Vertical Wind Shear, negative\n')
                 hd = self.heading_common(hd)
@@ -350,7 +354,7 @@ class pyIECWind_extreme():
             if self.shear_orient.lower() == 'both' or self.shear_orient.lower() == 'h':
                 # Horz
                 fname = self.case_name + '_EWS_H_N_U%2.1f.wnd'%V_hub_in
-                data = np.column_stack((t, V, V_dir, V_vert, shear_lin_n, shear_vert, np.zeros_like(t), V_gust))
+                data = np.column_stack((t, V, V_dir, V_vert, shear_lin_n, shear_vert, np.zeros_like(t), V_gust, upflow))
                 hd = []
                 hd.append('! Exteme Horizontal Wind Shear, negative\n')
                 hd = self.heading_common(hd)
@@ -380,16 +384,16 @@ class pyIECWind_extreme():
         if not os.path.isdir(self.outdir):
             os.makedirs(self.outdir)
 
-        # Move transcient event to user definted time
+        # Move transient event to user defined time
         data[:,0] += self.TStart
         data = np.vstack((data[0,:], data, data[-1,:]))
         data[0,0] = self.T0
         data[-1,0] = self.TF
 
         # Headers
-        hd1 = ['Time', 'Wind', 'Wind', 'Vertical', 'Horiz.', 'Pwr. Law', 'Lin. Vert.', 'Gust']
-        hd2 = ['', 'Speed', 'Dir', 'Speed', 'Shear', 'Vert. Shr', 'Shear', 'Speed']
-        hd3 = ['(s)', '(m/s)', '(deg)', '(m/s)', '(-)', '(-)', '(-)', '(m/s)', ]
+        hd1 = ['Time', 'Wind', 'Wind', 'Vertical', 'Horiz.', 'Pwr. Law', 'Lin. Vert.', 'Gust', 'Upflow']
+        hd2 = ['', 'Speed', 'Dir', 'Speed', 'Shear', 'Vert. Shr', 'Shear', 'Speed', 'Angle']
+        hd3 = ['(s)', '(m/s)', '(deg)', '(m/s)', '(-)', '(-)', '(-)', '(m/s)', '(deg)']
 
         self.fpath = os.path.join(self.outdir, fname)
         fid = open(self.fpath, 'w')

--- a/weis/aeroelasticse/rotor_loads_defl_strainsWEIS.py
+++ b/weis/aeroelasticse/rotor_loads_defl_strainsWEIS.py
@@ -1,5 +1,4 @@
 from openmdao.api import Group
-from wisdem.ccblade.ccblade_component import CCBladeLoads, AeroHubLoads
 from wisdem.rotorse.rotor_structure import BladeCurvature, TotalLoads, RunFrame3DD, TipDeflection, DesignConstraints
 
 

--- a/weis/aeroelasticse/rotor_loads_defl_strainsWEIS.py
+++ b/weis/aeroelasticse/rotor_loads_defl_strainsWEIS.py
@@ -8,53 +8,21 @@ class RotorLoadsDeflStrainsWEIS(Group):
     def initialize(self):
         self.options.declare('modeling_options')
         self.options.declare('opt_options')
-        self.options.declare('freq_run')
     def setup(self):
         modeling_options = self.options['modeling_options']
         opt_options      = self.options['opt_options']
-        freq_run         = self.options['freq_run']
 
         # Load blade with rated conditions and compute aerodynamic forces
         promoteListAeroLoads =  ['r', 'theta', 'chord', 'Rtip', 'Rhub', 'hub_height', 'precone', 'tilt', 'airfoils_aoa', 'airfoils_Re', 'airfoils_cl', 'airfoils_cd', 'airfoils_cm', 'nBlades', 'rho', 'mu', 'Omega_load','pitch_load']
-        # self.add_subsystem('aero_rated',        CCBladeLoads(modeling_options = modeling_options), promotes=promoteListAeroLoads)
-
-        if not (modeling_options['Level2']['flag'] == True or modeling_options['Level3']['flag'] == True) or modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 1 or freq_run:
-            self.add_subsystem('aero_gust',         CCBladeLoads(modeling_options = modeling_options), promotes=promoteListAeroLoads)
-        # self.add_subsystem('aero_storm_1yr',    CCBladeLoads(modeling_options = modeling_options), promotes=promoteListAeroLoads)
-        # self.add_subsystem('aero_storm_50yr',   CCBladeLoads(modeling_options = modeling_options), promotes=promoteListAeroLoads)
         # Add centrifugal and gravity loading to aero loading
         promotes=['tilt','theta','rhoA','z','totalCone','z_az']
         self.add_subsystem('curvature',         BladeCurvature(modeling_options = modeling_options),  promotes=['r','precone','precurve','presweep','3d_curv','x_az','y_az','z_az'])
         promoteListTotalLoads = ['r', 'theta', 'tilt', 'rhoA', '3d_curv', 'z_az']
         self.add_subsystem('tot_loads_gust',        TotalLoads(modeling_options = modeling_options),      promotes=promoteListTotalLoads)
-        # self.add_subsystem('tot_loads_rated',       TotalLoads(modeling_options = modeling_options),      promotes=promoteListTotalLoads)
-        # self.add_subsystem('tot_loads_storm_1yr',   TotalLoads(modeling_options = modeling_options),      promotes=promoteListTotalLoads)
-        # self.add_subsystem('tot_loads_storm_50yr',  TotalLoads(modeling_options = modeling_options),      promotes=promoteListTotalLoads)
         promoteListFrame3DD = ['x_az','y_az','z_az','theta','r','A','EA','EIxx','EIyy','EIxy','GJ','rhoA','rhoJ','x_ec','y_ec','xu_strain_spar','xl_strain_spar','yu_strain_spar','yl_strain_spar','xu_strain_te','xl_strain_te','yu_strain_te','yl_strain_te']
         self.add_subsystem('frame',     RunFrame3DD(modeling_options = modeling_options),      promotes=promoteListFrame3DD)
         self.add_subsystem('tip_pos',   TipDeflection(),                                  promotes=['tilt','pitch_load'])
-        if not (modeling_options['Level2']['flag'] == True or modeling_options['Level3']['flag'] == True) or modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 1 or freq_run:
-            self.add_subsystem('aero_hub_loads', AeroHubLoads(modeling_options = modeling_options), promotes = promoteListAeroLoads)
         self.add_subsystem('constr',    DesignConstraints(modeling_options = modeling_options, opt_options = opt_options))
-
-        # if modeling_options['rotorse']['FatigueMode'] > 0:
-        #     promoteListFatigue = ['r', 'gamma_f', 'gamma_m', 'E', 'Xt', 'Xc', 'x_tc', 'y_tc', 'EIxx', 'EIyy', 'pitch_axis', 'chord', 'layer_name', 'layer_mat', 'definition_layer', 'sc_ss_mats','sc_ps_mats','te_ss_mats','te_ps_mats','rthick']
-        #     self.add_subsystem('fatigue', BladeFatigue(modeling_options = modeling_options, opt_options = opt_options), promotes=promoteListFatigue)
-
-        # Aero loads to total loads
-        if not (modeling_options['Level2']['flag'] == True or modeling_options['Level3']['flag'] == True) or modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 1 or freq_run:
-            self.connect('aero_gust.loads_Px',      'tot_loads_gust.aeroloads_Px')
-            self.connect('aero_gust.loads_Py',      'tot_loads_gust.aeroloads_Py')
-            self.connect('aero_gust.loads_Pz',      'tot_loads_gust.aeroloads_Pz')
-        # self.connect('aero_rated.loads_Px',     'tot_loads_rated.aeroloads_Px')
-        # self.connect('aero_rated.loads_Py',     'tot_loads_rated.aeroloads_Py')
-        # self.connect('aero_rated.loads_Pz',     'tot_loads_rated.aeroloads_Pz')
-        # self.connect('aero_storm_1yr.loads_Px', 'tot_loads_storm_1yr.aeroloads_Px')
-        # self.connect('aero_storm_1yr.loads_Py', 'tot_loads_storm_1yr.aeroloads_Py')
-        # self.connect('aero_storm_1yr.loads_Pz', 'tot_loads_storm_1yr.aeroloads_Pz')
-        # self.connect('aero_storm_50yr.loads_Px', 'tot_loads_storm_50yr.aeroloads_Px')
-        # self.connect('aero_storm_50yr.loads_Py', 'tot_loads_storm_50yr.aeroloads_Py')
-        # self.connect('aero_storm_50yr.loads_Pz', 'tot_loads_storm_50yr.aeroloads_Pz')
 
         # Total loads to strains
         self.connect('tot_loads_gust.Px_af', 'frame.Px_af')

--- a/weis/glue_code/glue_code.py
+++ b/weis/glue_code/glue_code.py
@@ -71,140 +71,130 @@ class WindPark(om.Group):
         
         # Analysis components
         self.add_subsystem('wisdem',   wisdemPark(modeling_options = modeling_options, opt_options = opt_options), promotes=['*'])
-        self.add_subsystem('xf',        RunXFOIL(modeling_options = modeling_options, opt_options = opt_options)) # Recompute polars with xfoil (for flaps)
-    
+        
         if modeling_options['Level3']['flag']:
+            self.add_subsystem('xf',        RunXFOIL(modeling_options = modeling_options, opt_options = opt_options)) # Recompute polars with xfoil (for flaps)
             self.add_subsystem('sse_tune',          ServoSE_ROSCO(modeling_options = modeling_options)) # Aero analysis
             self.add_subsystem('aeroelastic',       FASTLoadCases(modeling_options = modeling_options, opt_options = opt_options))
             self.add_subsystem('stall_check_of',    NoStallConstraint(modeling_options = modeling_options))
-
-        self.add_subsystem('rlds_post',      RotorLoadsDeflStrainsWEIS(modeling_options = modeling_options, opt_options = opt_options, freq_run=False))
+            self.add_subsystem('rlds_post',      RotorLoadsDeflStrainsWEIS(modeling_options = modeling_options, opt_options = opt_options))
         
-        if modeling_options['WISDEM']['DriveSE']['flag']:
-            self.add_subsystem('drivese_post',   DrivetrainSE(modeling_options=modeling_options, n_dlcs=1))
-                                                
-        if modeling_options['WISDEM']['TowerSE']['flag']:
-            self.add_subsystem('towerse_post',   TowerSE(modeling_options=modeling_options))
-            self.add_subsystem('tcons_post',     TurbineConstraints(modeling_options = modeling_options))
+            if modeling_options['WISDEM']['DriveSE']['flag']:
+                self.add_subsystem('drivese_post',   DrivetrainSE(modeling_options=modeling_options, n_dlcs=1))
+                                                    
+            if modeling_options['WISDEM']['TowerSE']['flag']:
+                self.add_subsystem('towerse_post',   TowerSE(modeling_options=modeling_options))
+                self.add_subsystem('tcons_post',     TurbineConstraints(modeling_options = modeling_options))
             
-        self.add_subsystem('financese_post', PlantFinance(verbosity=modeling_options['General']['verbosity']))
+            self.add_subsystem('financese_post', PlantFinance(verbosity=modeling_options['General']['verbosity']))
             
-        # Post-processing
-        self.add_subsystem('outputs_2_screen_weis',  Outputs_2_Screen(modeling_options = modeling_options, opt_options = opt_options))
-        if opt_options['opt_flag']:
-            self.add_subsystem('conv_plots_weis',    Convergence_Trends_Opt(opt_options = opt_options))
+            # Post-processing
+            self.add_subsystem('outputs_2_screen_weis',  Outputs_2_Screen(modeling_options = modeling_options, opt_options = opt_options))
+            if opt_options['opt_flag']:
+                self.add_subsystem('conv_plots_weis',    Convergence_Trends_Opt(opt_options = opt_options))
 
-        # Connections to blade 
-        self.connect('dac_ivc.te_flap_end',             'blade.outer_shape_bem.span_end')
-        self.connect('dac_ivc.te_flap_ext',             'blade.outer_shape_bem.span_ext')
+            # Connections to blade 
+            self.connect('dac_ivc.te_flap_end',             'blade.outer_shape_bem.span_end')
+            self.connect('dac_ivc.te_flap_ext',             'blade.outer_shape_bem.span_ext')
 
-        # Connections from blade struct parametrization to rotor load anlysis
-        self.connect('blade.ps.s_opt_spar_cap_ss',   'rlds_post.constr.s_opt_spar_cap_ss')
-        self.connect('blade.ps.s_opt_spar_cap_ps',   'rlds_post.constr.s_opt_spar_cap_ps')
+            # Connections from blade struct parametrization to rotor load anlysis
+            self.connect('blade.ps.s_opt_spar_cap_ss',   'rlds_post.constr.s_opt_spar_cap_ss')
+            self.connect('blade.ps.s_opt_spar_cap_ps',   'rlds_post.constr.s_opt_spar_cap_ps')
+            
+            # Connections to run xfoil for te flaps
+            self.connect('blade.pa.chord_param',                  'xf.chord')
+            self.connect('blade.outer_shape_bem.s',               'xf.s')
+            self.connect('blade.interp_airfoils.coord_xy_interp', 'xf.coord_xy_interp')
+            self.connect('airfoils.aoa',                          'xf.aoa')
+            self.connect('assembly.r_blade',                      'xf.r')
+            self.connect('dac_ivc.te_flap_end',                   'xf.span_end')
+            self.connect('dac_ivc.te_flap_ext',                   'xf.span_ext')
+            self.connect('dac_ivc.chord_start',                   'xf.chord_start')
+            self.connect('dac_ivc.delta_max_pos',                 'xf.delta_max_pos')
+            self.connect('dac_ivc.delta_max_neg',                 'xf.delta_max_neg')
+            self.connect('env.speed_sound_air',                   'xf.speed_sound_air')
+            self.connect('env.rho_air',                           'xf.rho_air')
+            self.connect('env.mu_air',                            'xf.mu_air')
+            self.connect('control.rated_TSR',                     'xf.rated_TSR')
+            if modeling_options['flags']['control']:
+                self.connect('control.max_TS',                        'xf.max_TS')
+            self.connect('blade.interp_airfoils.cl_interp',       'xf.cl_interp')
+            self.connect('blade.interp_airfoils.cd_interp',       'xf.cd_interp')
+            self.connect('blade.interp_airfoils.cm_interp',       'xf.cm_interp')
 
-        # Connection from ra to rs for the rated conditions
-        # self.connect('rp.powercurve.rated_V',        'rlds_post.aero_rated.V_load')
-        if modeling_options['Level3']['ROSCO']['flag']:
-            if not modeling_options['Level3']['flag']:
-                self.connect('rp.gust.V_gust',              ['rlds_post.aero_gust.V_load', 'rlds_post.aero_hub_loads.V_load'])
-                self.connect('rp.powercurve.rated_Omega',   ['rlds_post.Omega_load', 'rlds_post.tot_loads_gust.aeroloads_Omega', 'rlds_post.constr.rated_Omega'])
-                self.connect('rp.powercurve.rated_pitch',   ['rlds_post.pitch_load', 'rlds_post.tot_loads_gust.aeroloads_pitch'])
-        
-        # Connections to run xfoil for te flaps
-        self.connect('blade.pa.chord_param',                  'xf.chord')
-        self.connect('blade.outer_shape_bem.s',               'xf.s')
-        self.connect('blade.interp_airfoils.coord_xy_interp', 'xf.coord_xy_interp')
-        self.connect('airfoils.aoa',                          'xf.aoa')
-        self.connect('assembly.r_blade',                      'xf.r')
-        self.connect('dac_ivc.te_flap_end',                   'xf.span_end')
-        self.connect('dac_ivc.te_flap_ext',                   'xf.span_ext')
-        self.connect('dac_ivc.chord_start',                   'xf.chord_start')
-        self.connect('dac_ivc.delta_max_pos',                 'xf.delta_max_pos')
-        self.connect('dac_ivc.delta_max_neg',                 'xf.delta_max_neg')
-        self.connect('env.speed_sound_air',                   'xf.speed_sound_air')
-        self.connect('env.rho_air',                           'xf.rho_air')
-        self.connect('env.mu_air',                            'xf.mu_air')
-        self.connect('control.rated_TSR',                     'xf.rated_TSR')
-        if modeling_options['flags']['control']:
-            self.connect('control.max_TS',                        'xf.max_TS')
-        self.connect('blade.interp_airfoils.cl_interp',       'xf.cl_interp')
-        self.connect('blade.interp_airfoils.cd_interp',       'xf.cd_interp')
-        self.connect('blade.interp_airfoils.cm_interp',       'xf.cm_interp')
+            if modeling_options['Level3']['ROSCO']['flag']:
+                self.connect('rp.powercurve.rated_V',         ['sse_tune.tune_rosco.v_rated'])
+                #self.connect('rp.gust.V_gust',                ['freq_rotor.aero_gust.V_load', 'freq_rotor.aero_hub_loads.V_load'])
+                self.connect('rp.powercurve.rated_Omega',     'sse_tune.tune_rosco.rated_rotor_speed')
+                #self.connect('rp.powercurve.rated_pitch',     ['freq_rotor.pitch_load', 'freq_rotor.tot_loads_gust.aeroloads_pitch'])
+                self.connect('rp.powercurve.rated_Q',          'sse_tune.tune_rosco.rated_torque')
 
-        if modeling_options['Level3']['flag'] and modeling_options['Level3']['ROSCO']['flag']:
-            self.connect('rp.powercurve.rated_V',         ['sse_tune.tune_rosco.v_rated'])
-            #self.connect('rp.gust.V_gust',                ['freq_rotor.aero_gust.V_load', 'freq_rotor.aero_hub_loads.V_load'])
-            self.connect('rp.powercurve.rated_Omega',     'sse_tune.tune_rosco.rated_rotor_speed')
-            #self.connect('rp.powercurve.rated_pitch',     ['freq_rotor.pitch_load', 'freq_rotor.tot_loads_gust.aeroloads_pitch'])
-            self.connect('rp.powercurve.rated_Q',          'sse_tune.tune_rosco.rated_torque')
+                self.connect('assembly.r_blade',               'sse_tune.r')
+                self.connect('assembly.rotor_radius',          'sse_tune.Rtip')
+                self.connect('hub.radius',                     'sse_tune.Rhub')
+                self.connect('assembly.hub_height',            'sse_tune.hub_height')
+                self.connect('hub.cone',                       'sse_tune.precone')
+                self.connect('nacelle.uptilt',                 'sse_tune.tilt')
+                self.connect('airfoils.aoa',                   'sse_tune.airfoils_aoa')
+                self.connect('airfoils.Re',                    'sse_tune.airfoils_Re')
+                self.connect('xf.cl_interp_flaps',             'sse_tune.airfoils_cl')
+                self.connect('xf.cd_interp_flaps',             'sse_tune.airfoils_cd')
+                self.connect('xf.cm_interp_flaps',             'sse_tune.airfoils_cm')
+                self.connect('configuration.n_blades',         'sse_tune.nBlades')
+                self.connect('env.rho_air',                    'sse_tune.rho')
+                self.connect('env.mu_air',                     'sse_tune.mu')
+                self.connect('blade.pa.chord_param',           'sse_tune.chord')
+                self.connect('blade.pa.twist_param',           'sse_tune.theta')
+                # Connections to the stall check
+                self.connect('blade.outer_shape_bem.s',        'stall_check_of.s')
+                self.connect('airfoils.aoa',                   'stall_check_of.airfoils_aoa')
+                self.connect('xf.cl_interp_flaps',             'stall_check_of.airfoils_cl')
+                self.connect('xf.cd_interp_flaps',             'stall_check_of.airfoils_cd')
+                self.connect('xf.cm_interp_flaps',             'stall_check_of.airfoils_cm')
+                self.connect('aeroelastic.max_aoa',            'stall_check_of.aoa_along_span')
 
-            self.connect('assembly.r_blade',               'sse_tune.r')
-            self.connect('assembly.rotor_radius',          'sse_tune.Rtip')
-            self.connect('hub.radius',                     'sse_tune.Rhub')
-            self.connect('assembly.hub_height',            'sse_tune.hub_height')
-            self.connect('hub.cone',                       'sse_tune.precone')
-            self.connect('nacelle.uptilt',                 'sse_tune.tilt')
-            self.connect('airfoils.aoa',                   'sse_tune.airfoils_aoa')
-            self.connect('airfoils.Re',                    'sse_tune.airfoils_Re')
-            self.connect('xf.cl_interp_flaps',             'sse_tune.airfoils_cl')
-            self.connect('xf.cd_interp_flaps',             'sse_tune.airfoils_cd')
-            self.connect('xf.cm_interp_flaps',             'sse_tune.airfoils_cm')
-            self.connect('configuration.n_blades',         'sse_tune.nBlades')
-            self.connect('env.rho_air',                    'sse_tune.rho')
-            self.connect('env.mu_air',                     'sse_tune.mu')
-            self.connect('blade.pa.chord_param',           'sse_tune.chord')
-            self.connect('blade.pa.twist_param',           'sse_tune.theta')
-            # Connections to the stall check
-            self.connect('blade.outer_shape_bem.s',        'stall_check_of.s')
-            self.connect('airfoils.aoa',                   'stall_check_of.airfoils_aoa')
-            self.connect('xf.cl_interp_flaps',             'stall_check_of.airfoils_cl')
-            self.connect('xf.cd_interp_flaps',             'stall_check_of.airfoils_cd')
-            self.connect('xf.cm_interp_flaps',             'stall_check_of.airfoils_cm')
-            self.connect('aeroelastic.max_aoa',            'stall_check_of.aoa_along_span')
+                self.connect('control.V_in' ,                   'sse_tune.v_min')
+                self.connect('control.V_out' ,                  'sse_tune.v_max')
+                self.connect('blade.outer_shape_bem.ref_axis',  'sse_tune.precurve', src_indices=om.slicer[:, 0])
+                self.connect('blade.outer_shape_bem.ref_axis',  'sse_tune.precurveTip', src_indices=[(-1, 0)])
+                self.connect('blade.outer_shape_bem.ref_axis',  'sse_tune.presweep', src_indices=om.slicer[:, 1])
+                self.connect('blade.outer_shape_bem.ref_axis',  'sse_tune.presweepTip', src_indices=[(-1, 1)])
+                self.connect('xf.flap_angles',                  'sse_tune.airfoils_Ctrl')
+                self.connect('control.minOmega',                'sse_tune.omega_min')
+                self.connect('control.rated_TSR',               'sse_tune.tsr_operational')
+                self.connect('configuration.rated_power',       'sse_tune.rated_power')
 
-            self.connect('control.V_in' ,                   'sse_tune.v_min')
-            self.connect('control.V_out' ,                  'sse_tune.v_max')
-            self.connect('blade.outer_shape_bem.ref_axis',  'sse_tune.precurve', src_indices=om.slicer[:, 0])
-            self.connect('blade.outer_shape_bem.ref_axis',  'sse_tune.precurveTip', src_indices=[(-1, 0)])
-            self.connect('blade.outer_shape_bem.ref_axis',  'sse_tune.presweep', src_indices=om.slicer[:, 1])
-            self.connect('blade.outer_shape_bem.ref_axis',  'sse_tune.presweepTip', src_indices=[(-1, 1)])
-            self.connect('xf.flap_angles',                  'sse_tune.airfoils_Ctrl')
-            self.connect('control.minOmega',                'sse_tune.omega_min')
-            self.connect('control.rated_TSR',               'sse_tune.tsr_operational')
-            self.connect('configuration.rated_power',       'sse_tune.rated_power')
-
-            self.connect('nacelle.gear_ratio',              'sse_tune.tune_rosco.gear_ratio')
-            self.connect('assembly.rotor_radius',           'sse_tune.tune_rosco.R')
-            self.connect('re.precomp.I_all_blades',    'sse_tune.tune_rosco.rotor_inertia', src_indices=[0])
-            self.connect('rs.frame.flap_mode_freqs','sse_tune.tune_rosco.flap_freq', src_indices=[0])
-            self.connect('rs.frame.edge_mode_freqs','sse_tune.tune_rosco.edge_freq', src_indices=[0])
-            self.connect('rp.powercurve.rated_efficiency', 'sse_tune.tune_rosco.generator_efficiency')
-            self.connect('nacelle.gearbox_efficiency',      'sse_tune.tune_rosco.gearbox_efficiency')
-            self.connect('tune_rosco_ivc.max_pitch',        'sse_tune.tune_rosco.max_pitch') 
-            self.connect('tune_rosco_ivc.min_pitch',        'sse_tune.tune_rosco.min_pitch')
-            self.connect('control.max_pitch_rate' ,         'sse_tune.tune_rosco.max_pitch_rate')
-            self.connect('control.max_torque_rate' ,        'sse_tune.tune_rosco.max_torque_rate')
-            self.connect('tune_rosco_ivc.vs_minspd',        'sse_tune.tune_rosco.vs_minspd') 
-            self.connect('tune_rosco_ivc.ss_vsgain',        'sse_tune.tune_rosco.ss_vsgain') 
-            self.connect('tune_rosco_ivc.ss_pcgain',        'sse_tune.tune_rosco.ss_pcgain') 
-            self.connect('tune_rosco_ivc.ps_percent',       'sse_tune.tune_rosco.ps_percent') 
-            self.connect('tune_rosco_ivc.PC_omega',         'sse_tune.tune_rosco.PC_omega')
-            self.connect('tune_rosco_ivc.PC_zeta',          'sse_tune.tune_rosco.PC_zeta')
-            self.connect('tune_rosco_ivc.VS_omega',         'sse_tune.tune_rosco.VS_omega')
-            self.connect('tune_rosco_ivc.VS_zeta',          'sse_tune.tune_rosco.VS_zeta')
-            self.connect('tune_rosco_ivc.IPC_Ki1p',         'sse_tune.tune_rosco.IPC_Ki1p')
-            self.connect('dac_ivc.delta_max_pos',           'sse_tune.tune_rosco.delta_max_pos')
-            if modeling_options['Level3']['ROSCO']['Flp_Mode'] > 0:
-                self.connect('tune_rosco_ivc.Flp_omega',    'sse_tune.tune_rosco.Flp_omega')
-                self.connect('tune_rosco_ivc.Flp_zeta',     'sse_tune.tune_rosco.Flp_zeta')
-                
-        elif modeling_options['Level3']['flag'] and modeling_options['Level3']['ROSCO']['flag']==False:
-            raise Exception("ERROR: WISDEM does not support openfast without the tuning of ROSCO")
-        else:
-            pass
-        
-        # Connections to aeroelasticse
-        if modeling_options['Level3']['flag']:
+                self.connect('nacelle.gear_ratio',              'sse_tune.tune_rosco.gear_ratio')
+                self.connect('assembly.rotor_radius',           'sse_tune.tune_rosco.R')
+                self.connect('re.precomp.I_all_blades',    'sse_tune.tune_rosco.rotor_inertia', src_indices=[0])
+                self.connect('rs.frame.flap_mode_freqs','sse_tune.tune_rosco.flap_freq', src_indices=[0])
+                self.connect('rs.frame.edge_mode_freqs','sse_tune.tune_rosco.edge_freq', src_indices=[0])
+                self.connect('rp.powercurve.rated_efficiency', 'sse_tune.tune_rosco.generator_efficiency')
+                self.connect('nacelle.gearbox_efficiency',      'sse_tune.tune_rosco.gearbox_efficiency')
+                self.connect('tune_rosco_ivc.max_pitch',        'sse_tune.tune_rosco.max_pitch') 
+                self.connect('tune_rosco_ivc.min_pitch',        'sse_tune.tune_rosco.min_pitch')
+                self.connect('control.max_pitch_rate' ,         'sse_tune.tune_rosco.max_pitch_rate')
+                self.connect('control.max_torque_rate' ,        'sse_tune.tune_rosco.max_torque_rate')
+                self.connect('tune_rosco_ivc.vs_minspd',        'sse_tune.tune_rosco.vs_minspd') 
+                self.connect('tune_rosco_ivc.ss_vsgain',        'sse_tune.tune_rosco.ss_vsgain') 
+                self.connect('tune_rosco_ivc.ss_pcgain',        'sse_tune.tune_rosco.ss_pcgain') 
+                self.connect('tune_rosco_ivc.ps_percent',       'sse_tune.tune_rosco.ps_percent') 
+                self.connect('tune_rosco_ivc.PC_omega',         'sse_tune.tune_rosco.PC_omega')
+                self.connect('tune_rosco_ivc.PC_zeta',          'sse_tune.tune_rosco.PC_zeta')
+                self.connect('tune_rosco_ivc.VS_omega',         'sse_tune.tune_rosco.VS_omega')
+                self.connect('tune_rosco_ivc.VS_zeta',          'sse_tune.tune_rosco.VS_zeta')
+                self.connect('tune_rosco_ivc.IPC_Ki1p',         'sse_tune.tune_rosco.IPC_Ki1p')
+                self.connect('dac_ivc.delta_max_pos',           'sse_tune.tune_rosco.delta_max_pos')
+                if modeling_options['Level3']['ROSCO']['Flp_Mode'] > 0:
+                    self.connect('tune_rosco_ivc.Flp_omega',    'sse_tune.tune_rosco.Flp_omega')
+                    self.connect('tune_rosco_ivc.Flp_zeta',     'sse_tune.tune_rosco.Flp_zeta')
+                    
+            elif modeling_options['Level3']['ROSCO']['flag']==False:
+                raise Exception("ERROR: WISDEM does not support openfast without the tuning of ROSCO")
+            else:
+                pass
+            
+            # Connections to aeroelasticse
             self.connect('blade.outer_shape_bem.ref_axis',  'aeroelastic.ref_axis_blade')
             self.connect('configuration.rotor_orientation', 'aeroelastic.rotor_orientation')
             self.connect('assembly.r_blade',                'aeroelastic.r')
@@ -322,7 +312,7 @@ class WindPark(om.Group):
             self.connect('xf.Ma_loc',                       'aeroelastic.airfoils_Ma_loc')
             self.connect('xf.flap_angles',                  'aeroelastic.airfoils_Ctrl')
         
-            if modeling_options['Level3']['flag'] and modeling_options['openfast']['dlc_settings']['run_blade_fatigue']:
+            if modeling_options['openfast']['dlc_settings']['run_blade_fatigue']:
                 self.connect('re.precomp.x_tc',                            'aeroelastic.x_tc')
                 self.connect('re.precomp.y_tc',                            'aeroelastic.y_tc')
                 self.connect('materials.E',                                     'aeroelastic.E')
@@ -340,345 +330,323 @@ class WindPark(om.Group):
                 # self.connect('gamma_m',     'rlds_post.gamma_m')
                 # self.connect('gamma_f',     'rlds_post.gamma_f') # TODO
 
-        # Connections to rotor load analysis
-        if modeling_options['Level3']['flag'] and modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 2:
+            # Connections to rotor load analysis
             self.connect('aeroelastic.loads_Px',      'rlds_post.tot_loads_gust.aeroloads_Px')
             self.connect('aeroelastic.loads_Py',      'rlds_post.tot_loads_gust.aeroloads_Py')
             self.connect('aeroelastic.loads_Pz',      'rlds_post.tot_loads_gust.aeroloads_Pz')
             self.connect('aeroelastic.loads_Omega',   'rlds_post.tot_loads_gust.aeroloads_Omega')
             self.connect('aeroelastic.loads_pitch',   'rlds_post.tot_loads_gust.aeroloads_pitch')
             self.connect('aeroelastic.loads_azimuth', 'rlds_post.tot_loads_gust.aeroloads_azimuth')
-        else:
-            self.connect('xf.cl_interp_flaps',        'rlds_post.airfoils_cl')
-            self.connect('xf.cd_interp_flaps',        'rlds_post.airfoils_cd')
-            self.connect('xf.cm_interp_flaps',        'rlds_post.airfoils_cm')
-            self.connect('airfoils.aoa',              'rlds_post.airfoils_aoa')
-            self.connect('airfoils.Re',               'rlds_post.airfoils_Re')
-            self.connect('assembly.rotor_radius',     'rlds_post.Rtip')
-            self.connect('hub.radius',                'rlds_post.Rhub')
-            self.connect('env.rho_air',               'rlds_post.rho')
-            self.connect('env.mu_air',                'rlds_post.mu')
-            self.connect('env.shear_exp',             'rlds_post.aero_hub_loads.shearExp')
-            self.connect('assembly.hub_height',       'rlds_post.hub_height')
-            self.connect('configuration.n_blades',    'rlds_post.nBlades')
-        self.connect('assembly.r_blade',          'rlds_post.r')
-        self.connect('hub.cone',                  'rlds_post.precone')
-        self.connect('nacelle.uptilt',            'rlds_post.tilt')
+            self.connect('assembly.r_blade',          'rlds_post.r')
+            self.connect('hub.cone',                  'rlds_post.precone')
+            self.connect('nacelle.uptilt',            'rlds_post.tilt')
 
-        self.connect('re.A',    'rlds_post.A')
-        self.connect('re.EA',   'rlds_post.EA')
-        self.connect('re.EIxx', 'rlds_post.EIxx')
-        self.connect('re.EIyy', 'rlds_post.EIyy')
-        self.connect('re.GJ',   'rlds_post.GJ')
-        self.connect('re.rhoA', 'rlds_post.rhoA')
-        self.connect('re.rhoJ', 'rlds_post.rhoJ')
-        self.connect('re.x_ec', 'rlds_post.x_ec')
-        self.connect('re.y_ec', 'rlds_post.y_ec')
-        self.connect('re.precomp.xu_strain_spar', 'rlds_post.xu_strain_spar')
-        self.connect('re.precomp.xl_strain_spar', 'rlds_post.xl_strain_spar')
-        self.connect('re.precomp.yu_strain_spar', 'rlds_post.yu_strain_spar')
-        self.connect('re.precomp.yl_strain_spar', 'rlds_post.yl_strain_spar')
-        self.connect('re.precomp.xu_strain_te',   'rlds_post.xu_strain_te')
-        self.connect('re.precomp.xl_strain_te',   'rlds_post.xl_strain_te')
-        self.connect('re.precomp.yu_strain_te',   'rlds_post.yu_strain_te')
-        self.connect('re.precomp.yl_strain_te',   'rlds_post.yl_strain_te')
-        self.connect('blade.outer_shape_bem.s','rlds_post.constr.s')
+            self.connect('re.A',    'rlds_post.A')
+            self.connect('re.EA',   'rlds_post.EA')
+            self.connect('re.EIxx', 'rlds_post.EIxx')
+            self.connect('re.EIyy', 'rlds_post.EIyy')
+            self.connect('re.GJ',   'rlds_post.GJ')
+            self.connect('re.rhoA', 'rlds_post.rhoA')
+            self.connect('re.rhoJ', 'rlds_post.rhoJ')
+            self.connect('re.x_ec', 'rlds_post.x_ec')
+            self.connect('re.y_ec', 'rlds_post.y_ec')
+            self.connect('re.precomp.xu_strain_spar', 'rlds_post.xu_strain_spar')
+            self.connect('re.precomp.xl_strain_spar', 'rlds_post.xl_strain_spar')
+            self.connect('re.precomp.yu_strain_spar', 'rlds_post.yu_strain_spar')
+            self.connect('re.precomp.yl_strain_spar', 'rlds_post.yl_strain_spar')
+            self.connect('re.precomp.xu_strain_te',   'rlds_post.xu_strain_te')
+            self.connect('re.precomp.xl_strain_te',   'rlds_post.xl_strain_te')
+            self.connect('re.precomp.yu_strain_te',   'rlds_post.yu_strain_te')
+            self.connect('re.precomp.yl_strain_te',   'rlds_post.yl_strain_te')
+            self.connect('blade.outer_shape_bem.s','rlds_post.constr.s')
 
-        # Connections to DriveSE
-        if modeling_options['WISDEM']['DriveSE']['flag']:
-            self.connect('hub.diameter'                    , 'drivese_post.hub_diameter')
-            self.connect('hub.hub_in2out_circ'             , 'drivese_post.hub_in2out_circ')
-            self.connect('hub.flange_t2shell_t'            , 'drivese_post.flange_t2shell_t')
-            self.connect('hub.flange_OD2hub_D'             , 'drivese_post.flange_OD2hub_D')
-            self.connect('hub.flange_ID2flange_OD'         , 'drivese_post.flange_ID2flange_OD')
-            self.connect('hub.hub_stress_concentration'    , 'drivese_post.hub_stress_concentration')
-            self.connect('hub.n_front_brackets'            , 'drivese_post.n_front_brackets')
-            self.connect('hub.n_rear_brackets'             , 'drivese_post.n_rear_brackets')
-            self.connect('hub.clearance_hub_spinner'       , 'drivese_post.clearance_hub_spinner')
-            self.connect('hub.spin_hole_incr'              , 'drivese_post.spin_hole_incr')
-            self.connect('hub.pitch_system_scaling_factor' , 'drivese_post.pitch_system_scaling_factor')
-            self.connect('hub.spinner_gust_ws'             , 'drivese_post.spinner_gust_ws')
+            # Connections to DriveSE
+            if modeling_options['WISDEM']['DriveSE']['flag']:
+                self.connect('hub.diameter'                    , 'drivese_post.hub_diameter')
+                self.connect('hub.hub_in2out_circ'             , 'drivese_post.hub_in2out_circ')
+                self.connect('hub.flange_t2shell_t'            , 'drivese_post.flange_t2shell_t')
+                self.connect('hub.flange_OD2hub_D'             , 'drivese_post.flange_OD2hub_D')
+                self.connect('hub.flange_ID2flange_OD'         , 'drivese_post.flange_ID2flange_OD')
+                self.connect('hub.hub_stress_concentration'    , 'drivese_post.hub_stress_concentration')
+                self.connect('hub.n_front_brackets'            , 'drivese_post.n_front_brackets')
+                self.connect('hub.n_rear_brackets'             , 'drivese_post.n_rear_brackets')
+                self.connect('hub.clearance_hub_spinner'       , 'drivese_post.clearance_hub_spinner')
+                self.connect('hub.spin_hole_incr'              , 'drivese_post.spin_hole_incr')
+                self.connect('hub.pitch_system_scaling_factor' , 'drivese_post.pitch_system_scaling_factor')
+                self.connect('hub.spinner_gust_ws'             , 'drivese_post.spinner_gust_ws')
+                self.connect('configuration.n_blades',          'drivese_post.n_blades')
+                self.connect('assembly.rotor_diameter',    'drivese_post.rotor_diameter')
+                self.connect('configuration.upwind',       'drivese_post.upwind')
+                self.connect('control.minOmega' ,          'drivese_post.minimum_rpm')
+                self.connect('rp.powercurve.rated_Omega',  'drivese_post.rated_rpm')
+                self.connect('rp.powercurve.rated_Q',      'drivese_post.rated_torque')
+                self.connect('configuration.rated_power',  'drivese_post.machine_rating')    
+                self.connect('tower.diameter',             'drivese_post.D_top', src_indices=[-1])
+                self.connect('aeroelastic.Fxyz',           'drivese_post.F_hub')
+                self.connect('aeroelastic.Mxyz',           'drivese_post.M_hub')
+                self.connect('rlds_post.frame.root_M',     'drivese_post.pitch_system.BRFM', src_indices=[1])
+                self.connect('blade.pa.chord_param',         'drivese_post.blade_root_diameter', src_indices=[0])
+                self.connect('re.precomp.blade_mass',        'drivese_post.blade_mass')
+                self.connect('re.precomp.mass_all_blades',   'drivese_post.blades_mass')
+                self.connect('re.precomp.I_all_blades',      'drivese_post.blades_I')
 
-            self.connect('configuration.n_blades',          'drivese_post.n_blades')
-            
-            self.connect('assembly.rotor_diameter',    'drivese_post.rotor_diameter')
-            self.connect('configuration.upwind',       'drivese_post.upwind')
-            self.connect('control.minOmega' ,          'drivese_post.minimum_rpm')
-            self.connect('rp.powercurve.rated_Omega',  'drivese_post.rated_rpm')
-            self.connect('rp.powercurve.rated_Q',      'drivese_post.rated_torque')
-            self.connect('configuration.rated_power',  'drivese_post.machine_rating')    
-            self.connect('tower.diameter',             'drivese_post.D_top', src_indices=[-1])
-            
-            if modeling_options['Level3']['flag'] and modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 2:
-                self.connect('aeroelastic.Fxyz', 'drivese_post.F_hub')
-                self.connect('aeroelastic.Mxyz', 'drivese_post.M_hub')
-            else:
-                self.connect('rlds_post.aero_hub_loads.Fxyz_hub_aero', 'drivese_post.F_hub')
-                self.connect('rlds_post.aero_hub_loads.Mxyz_hub_aero', 'drivese_post.M_hub')
-            self.connect('rlds_post.frame.root_M',                 'drivese_post.pitch_system.BRFM', src_indices=[1])
-                
-            self.connect('blade.pa.chord_param',              'drivese_post.blade_root_diameter', src_indices=[0])
-            self.connect('re.precomp.blade_mass',        'drivese_post.blade_mass')
-            self.connect('re.precomp.mass_all_blades',   'drivese_post.blades_mass')
-            self.connect('re.precomp.I_all_blades',      'drivese_post.blades_I')
-
-            self.connect('nacelle.distance_hub2mb',           'drivese_post.L_h1')
-            self.connect('nacelle.distance_mb2mb',            'drivese_post.L_12')
-            self.connect('nacelle.L_generator',               'drivese_post.L_generator')
-            self.connect('nacelle.overhang',                  'drivese_post.overhang')
-            self.connect('nacelle.distance_tt_hub',           'drivese_post.drive_height')
-            self.connect('nacelle.uptilt',                    'drivese_post.tilt')
-            self.connect('nacelle.gear_ratio',                'drivese_post.gear_ratio')
-            self.connect('nacelle.mb1Type',                   'drivese_post.bear1.bearing_type')
-            self.connect('nacelle.mb2Type',                   'drivese_post.bear2.bearing_type')
-            self.connect('nacelle.lss_diameter',              'drivese_post.lss_diameter')
-            self.connect('nacelle.lss_wall_thickness',        'drivese_post.lss_wall_thickness')
-            if modeling_options['WISDEM']['DriveSE']['direct']:
-                self.connect('nacelle.nose_diameter',              'drivese_post.bear1.D_shaft', src_indices=[0])
-                self.connect('nacelle.nose_diameter',              'drivese_post.bear2.D_shaft', src_indices=[-1])
-            else:
-                self.connect('nacelle.lss_diameter',              'drivese_post.bear1.D_shaft', src_indices=[0])
-                self.connect('nacelle.lss_diameter',              'drivese_post.bear2.D_shaft', src_indices=[-1])
-            self.connect('nacelle.uptower',                   'drivese_post.uptower')
-            self.connect('nacelle.brake_mass_user',           'drivese_post.brake_mass_user')
-            self.connect('nacelle.hvac_mass_coeff',           'drivese_post.hvac_mass_coeff')
-            self.connect('nacelle.converter_mass_user',       'drivese_post.converter_mass_user')
-            self.connect('nacelle.transformer_mass_user',     'drivese_post.transformer_mass_user')
-
-            if modeling_options['WISDEM']['DriveSE']['direct']:
-                self.connect('nacelle.nose_diameter',             'drivese_post.nose_diameter') # only used in direct
-                self.connect('nacelle.nose_wall_thickness',       'drivese_post.nose_wall_thickness') # only used in direct
-                self.connect('nacelle.bedplate_wall_thickness',   'drivese_post.bedplate_wall_thickness') # only used in direct
-            else:
-                self.connect('nacelle.hss_length',                'drivese_post.L_hss') # only used in geared
-                self.connect('nacelle.hss_diameter',              'drivese_post.hss_diameter') # only used in geared
-                self.connect('nacelle.hss_wall_thickness',        'drivese_post.hss_wall_thickness') # only used in geared
-                self.connect('nacelle.hss_material',              'drivese_post.hss_material')
-                self.connect('nacelle.planet_numbers',            'drivese_post.planet_numbers') # only used in geared
-                self.connect('nacelle.gear_configuration',        'drivese_post.gear_configuration') # only used in geared
-                self.connect('nacelle.bedplate_flange_width',     'drivese_post.bedplate_flange_width') # only used in geared
-                self.connect('nacelle.bedplate_flange_thickness', 'drivese_post.bedplate_flange_thickness') # only used in geared
-                self.connect('nacelle.bedplate_web_thickness',    'drivese_post.bedplate_web_thickness') # only used in geared
-                
-            self.connect('hub.hub_material',                  'drivese_post.hub_material')
-            self.connect('hub.spinner_material',              'drivese_post.spinner_material')
-            self.connect('nacelle.lss_material',              'drivese_post.lss_material')
-            self.connect('nacelle.bedplate_material',         'drivese_post.bedplate_material')
-            self.connect('materials.name',                    'drivese_post.material_names')
-            self.connect('materials.E',                       'drivese_post.E_mat')
-            self.connect('materials.G',                       'drivese_post.G_mat')
-            self.connect('materials.rho',                     'drivese_post.rho_mat')
-            self.connect('materials.sigma_y',                 'drivese_post.sigma_y_mat')
-            self.connect('materials.Xt',                      'drivese_post.Xt_mat')
-            self.connect('materials.unit_cost',               'drivese_post.unit_cost_mat')
-
-            if modeling_options['flags']['generator']:
-
-                self.connect('generator.B_r'          , 'drivese_post.generator.B_r')
-                self.connect('generator.P_Fe0e'       , 'drivese_post.generator.P_Fe0e')
-                self.connect('generator.P_Fe0h'       , 'drivese_post.generator.P_Fe0h')
-                self.connect('generator.S_N'          , 'drivese_post.generator.S_N')
-                self.connect('generator.alpha_p'      , 'drivese_post.generator.alpha_p')
-                self.connect('generator.b_r_tau_r'    , 'drivese_post.generator.b_r_tau_r')
-                self.connect('generator.b_ro'         , 'drivese_post.generator.b_ro')
-                self.connect('generator.b_s_tau_s'    , 'drivese_post.generator.b_s_tau_s')
-                self.connect('generator.b_so'         , 'drivese_post.generator.b_so')
-                self.connect('generator.cofi'         , 'drivese_post.generator.cofi')
-                self.connect('generator.freq'         , 'drivese_post.generator.freq')
-                self.connect('generator.h_i'          , 'drivese_post.generator.h_i')
-                self.connect('generator.h_sy0'        , 'drivese_post.generator.h_sy0')
-                self.connect('generator.h_w'          , 'drivese_post.generator.h_w')
-                self.connect('generator.k_fes'        , 'drivese_post.generator.k_fes')
-                self.connect('generator.k_fillr'      , 'drivese_post.generator.k_fillr')
-                self.connect('generator.k_fills'      , 'drivese_post.generator.k_fills')
-                self.connect('generator.k_s'          , 'drivese_post.generator.k_s')
-                self.connect('generator.m'            , 'drivese_post.generator.m')
-                self.connect('generator.mu_0'         , 'drivese_post.generator.mu_0')
-                self.connect('generator.mu_r'         , 'drivese_post.generator.mu_r')
-                self.connect('generator.p'            , 'drivese_post.generator.p')
-                self.connect('generator.phi'          , 'drivese_post.generator.phi')
-                self.connect('generator.q1'           , 'drivese_post.generator.q1')
-                self.connect('generator.q2'           , 'drivese_post.generator.q2')
-                self.connect('generator.ratio_mw2pp'  , 'drivese_post.generator.ratio_mw2pp')
-                self.connect('generator.resist_Cu'    , 'drivese_post.generator.resist_Cu')
-                self.connect('generator.sigma'        , 'drivese_post.generator.sigma')
-                self.connect('generator.y_tau_p'      , 'drivese_post.generator.y_tau_p')
-                self.connect('generator.y_tau_pr'     , 'drivese_post.generator.y_tau_pr')
-
-                self.connect('generator.I_0'          , 'drivese_post.generator.I_0')
-                self.connect('generator.d_r'          , 'drivese_post.generator.d_r')
-                self.connect('generator.h_m'          , 'drivese_post.generator.h_m')
-                self.connect('generator.h_0'          , 'drivese_post.generator.h_0')
-                self.connect('generator.h_s'          , 'drivese_post.generator.h_s')
-                self.connect('generator.len_s'        , 'drivese_post.generator.len_s')
-                self.connect('generator.n_r'          , 'drivese_post.generator.n_r')
-                self.connect('generator.rad_ag'       , 'drivese_post.generator.rad_ag')
-                self.connect('generator.t_wr'         , 'drivese_post.generator.t_wr')
-
-                self.connect('generator.n_s'          , 'drivese_post.generator.n_s')
-                self.connect('generator.b_st'         , 'drivese_post.generator.b_st')
-                self.connect('generator.d_s'          , 'drivese_post.generator.d_s')
-                self.connect('generator.t_ws'         , 'drivese_post.generator.t_ws')
-
-                self.connect('generator.rho_Copper'   , 'drivese_post.generator.rho_Copper')
-                self.connect('generator.rho_Fe'       , 'drivese_post.generator.rho_Fe')
-                self.connect('generator.rho_Fes'      , 'drivese_post.generator.rho_Fes')
-                self.connect('generator.rho_PM'       , 'drivese_post.generator.rho_PM')
-
-                self.connect('generator.C_Cu'         , 'drivese_post.generator.C_Cu')
-                self.connect('generator.C_Fe'         , 'drivese_post.generator.C_Fe')
-                self.connect('generator.C_Fes'        , 'drivese_post.generator.C_Fes')
-                self.connect('generator.C_PM'         , 'drivese_post.generator.C_PM')
-
-                if modeling_options['GeneratorSE']['type'] in ['pmsg_outer']:
-                    self.connect('generator.N_c'          , 'drivese_post.generator.N_c')
-                    self.connect('generator.b'            , 'drivese_post.generator.b')
-                    self.connect('generator.c'            , 'drivese_post.generator.c')
-                    self.connect('generator.E_p'          , 'drivese_post.generator.E_p')
-                    self.connect('generator.h_yr'         , 'drivese_post.generator.h_yr')
-                    self.connect('generator.h_ys'         , 'drivese_post.generator.h_ys')
-                    self.connect('generator.h_sr'         , 'drivese_post.generator.h_sr')
-                    self.connect('generator.h_ss'         , 'drivese_post.generator.h_ss')
-                    self.connect('generator.t_r'          , 'drivese_post.generator.t_r')
-                    self.connect('generator.t_s'          , 'drivese_post.generator.t_s')
-
-                    self.connect('generator.u_allow_pcent', 'drivese_post.generator.u_allow_pcent')
-                    self.connect('generator.y_allow_pcent', 'drivese_post.generator.y_allow_pcent')
-                    self.connect('generator.z_allow_deg'  , 'drivese_post.generator.z_allow_deg')
-                    self.connect('generator.B_tmax'       , 'drivese_post.generator.B_tmax')
-                    self.connect('rp.powercurve.rated_mech', 'drivese_post.generator.P_mech')
-
-                if modeling_options['GeneratorSE']['type'] in ['eesg','pmsg_arms','pmsg_disc']:
-                    self.connect('generator.tau_p'        , 'drivese_post.generator.tau_p')
-                    self.connect('generator.h_ys'         , 'drivese_post.generator.h_ys')
-                    self.connect('generator.h_yr'         , 'drivese_post.generator.h_yr')
-                    self.connect('generator.b_arm'        , 'drivese_post.generator.b_arm')
-
-                elif modeling_options['GeneratorSE']['type'] in ['scig','dfig']:
-                    self.connect('generator.B_symax'      , 'drivese_post.generator.B_symax')
-                    self.connect('generator.S_Nmax'      , 'drivese_post.generator.S_Nmax')
+                self.connect('nacelle.distance_hub2mb',           'drivese_post.L_h1')
+                self.connect('nacelle.distance_mb2mb',            'drivese_post.L_12')
+                self.connect('nacelle.L_generator',               'drivese_post.L_generator')
+                self.connect('nacelle.overhang',                  'drivese_post.overhang')
+                self.connect('nacelle.distance_tt_hub',           'drivese_post.drive_height')
+                self.connect('nacelle.uptilt',                    'drivese_post.tilt')
+                self.connect('nacelle.gear_ratio',                'drivese_post.gear_ratio')
+                self.connect('nacelle.mb1Type',                   'drivese_post.bear1.bearing_type')
+                self.connect('nacelle.mb2Type',                   'drivese_post.bear2.bearing_type')
+                self.connect('nacelle.lss_diameter',              'drivese_post.lss_diameter')
+                self.connect('nacelle.lss_wall_thickness',        'drivese_post.lss_wall_thickness')
+                if modeling_options['WISDEM']['DriveSE']['direct']:
+                    self.connect('nacelle.nose_diameter',              'drivese_post.bear1.D_shaft', src_indices=[0])
+                    self.connect('nacelle.nose_diameter',              'drivese_post.bear2.D_shaft', src_indices=[-1])
+                else:
+                    self.connect('nacelle.lss_diameter',              'drivese_post.bear1.D_shaft', src_indices=[0])
+                    self.connect('nacelle.lss_diameter',              'drivese_post.bear2.D_shaft', src_indices=[-1])
+                self.connect('nacelle.uptower',                   'drivese_post.uptower')
+                self.connect('nacelle.brake_mass_user',           'drivese_post.brake_mass_user')
+                self.connect('nacelle.hvac_mass_coeff',           'drivese_post.hvac_mass_coeff')
+                self.connect('nacelle.converter_mass_user',       'drivese_post.converter_mass_user')
+                self.connect('nacelle.transformer_mass_user',     'drivese_post.transformer_mass_user')
 
                 if modeling_options['WISDEM']['DriveSE']['direct']:
-                    self.connect('nacelle.nose_diameter',             'drivese_post.generator.D_nose', src_indices=[-1])
-                    self.connect('nacelle.lss_diameter',              'drivese_post.generator.D_shaft', src_indices=[0])
+                    self.connect('nacelle.nose_diameter',             'drivese_post.nose_diameter') # only used in direct
+                    self.connect('nacelle.nose_wall_thickness',       'drivese_post.nose_wall_thickness') # only used in direct
+                    self.connect('nacelle.bedplate_wall_thickness',   'drivese_post.bedplate_wall_thickness') # only used in direct
                 else:
-                    self.connect('nacelle.hss_diameter',              'drivese_post.generator.D_shaft', src_indices=[-1])
+                    self.connect('nacelle.hss_length',                'drivese_post.L_hss') # only used in geared
+                    self.connect('nacelle.hss_diameter',              'drivese_post.hss_diameter') # only used in geared
+                    self.connect('nacelle.hss_wall_thickness',        'drivese_post.hss_wall_thickness') # only used in geared
+                    self.connect('nacelle.hss_material',              'drivese_post.hss_material')
+                    self.connect('nacelle.planet_numbers',            'drivese_post.planet_numbers') # only used in geared
+                    self.connect('nacelle.gear_configuration',        'drivese_post.gear_configuration') # only used in geared
+                    self.connect('nacelle.bedplate_flange_width',     'drivese_post.bedplate_flange_width') # only used in geared
+                    self.connect('nacelle.bedplate_flange_thickness', 'drivese_post.bedplate_flange_thickness') # only used in geared
+                    self.connect('nacelle.bedplate_web_thickness',    'drivese_post.bedplate_web_thickness') # only used in geared
+                    
+                self.connect('hub.hub_material',                  'drivese_post.hub_material')
+                self.connect('hub.spinner_material',              'drivese_post.spinner_material')
+                self.connect('nacelle.lss_material',              'drivese_post.lss_material')
+                self.connect('nacelle.bedplate_material',         'drivese_post.bedplate_material')
+                self.connect('materials.name',                    'drivese_post.material_names')
+                self.connect('materials.E',                       'drivese_post.E_mat')
+                self.connect('materials.G',                       'drivese_post.G_mat')
+                self.connect('materials.rho',                     'drivese_post.rho_mat')
+                self.connect('materials.sigma_y',                 'drivese_post.sigma_y_mat')
+                self.connect('materials.Xt',                      'drivese_post.Xt_mat')
+                self.connect('materials.unit_cost',               'drivese_post.unit_cost_mat')
 
-            else:
-                self.connect('generator.generator_mass_user', 'drivese_post.generator_mass_user')
-                self.connect('generator.generator_efficiency_user', 'drivese_post.generator_efficiency_user')
+                if modeling_options['flags']['generator']:
 
-        # Connections to TowerSE
-        if modeling_options['WISDEM']['DriveSE']['flag'] and modeling_options['WISDEM']['TowerSE']['flag']:
-            self.connect('drivese_post.base_F',                'towerse_post.pre.rna_F')
-            self.connect('drivese_post.base_M',                'towerse_post.pre.rna_M')
-            self.connect('drivese_post.rna_I_TT',             'towerse_post.rna_I')
-            self.connect('drivese_post.rna_cm',               'towerse_post.rna_cg')
-            self.connect('drivese_post.rna_mass',             'towerse_post.rna_mass')
-            
-            if modeling_options['Level3']['ROSCO']['flag']:
-                self.connect('rp.gust.V_gust',               'towerse_post.wind.Uref')
+                    self.connect('generator.B_r'          , 'drivese_post.generator.B_r')
+                    self.connect('generator.P_Fe0e'       , 'drivese_post.generator.P_Fe0e')
+                    self.connect('generator.P_Fe0h'       , 'drivese_post.generator.P_Fe0h')
+                    self.connect('generator.S_N'          , 'drivese_post.generator.S_N')
+                    self.connect('generator.alpha_p'      , 'drivese_post.generator.alpha_p')
+                    self.connect('generator.b_r_tau_r'    , 'drivese_post.generator.b_r_tau_r')
+                    self.connect('generator.b_ro'         , 'drivese_post.generator.b_ro')
+                    self.connect('generator.b_s_tau_s'    , 'drivese_post.generator.b_s_tau_s')
+                    self.connect('generator.b_so'         , 'drivese_post.generator.b_so')
+                    self.connect('generator.cofi'         , 'drivese_post.generator.cofi')
+                    self.connect('generator.freq'         , 'drivese_post.generator.freq')
+                    self.connect('generator.h_i'          , 'drivese_post.generator.h_i')
+                    self.connect('generator.h_sy0'        , 'drivese_post.generator.h_sy0')
+                    self.connect('generator.h_w'          , 'drivese_post.generator.h_w')
+                    self.connect('generator.k_fes'        , 'drivese_post.generator.k_fes')
+                    self.connect('generator.k_fillr'      , 'drivese_post.generator.k_fillr')
+                    self.connect('generator.k_fills'      , 'drivese_post.generator.k_fills')
+                    self.connect('generator.k_s'          , 'drivese_post.generator.k_s')
+                    self.connect('generator.m'            , 'drivese_post.generator.m')
+                    self.connect('generator.mu_0'         , 'drivese_post.generator.mu_0')
+                    self.connect('generator.mu_r'         , 'drivese_post.generator.mu_r')
+                    self.connect('generator.p'            , 'drivese_post.generator.p')
+                    self.connect('generator.phi'          , 'drivese_post.generator.phi')
+                    self.connect('generator.q1'           , 'drivese_post.generator.q1')
+                    self.connect('generator.q2'           , 'drivese_post.generator.q2')
+                    self.connect('generator.ratio_mw2pp'  , 'drivese_post.generator.ratio_mw2pp')
+                    self.connect('generator.resist_Cu'    , 'drivese_post.generator.resist_Cu')
+                    self.connect('generator.sigma'        , 'drivese_post.generator.sigma')
+                    self.connect('generator.y_tau_p'      , 'drivese_post.generator.y_tau_p')
+                    self.connect('generator.y_tau_pr'     , 'drivese_post.generator.y_tau_pr')
+
+                    self.connect('generator.I_0'          , 'drivese_post.generator.I_0')
+                    self.connect('generator.d_r'          , 'drivese_post.generator.d_r')
+                    self.connect('generator.h_m'          , 'drivese_post.generator.h_m')
+                    self.connect('generator.h_0'          , 'drivese_post.generator.h_0')
+                    self.connect('generator.h_s'          , 'drivese_post.generator.h_s')
+                    self.connect('generator.len_s'        , 'drivese_post.generator.len_s')
+                    self.connect('generator.n_r'          , 'drivese_post.generator.n_r')
+                    self.connect('generator.rad_ag'       , 'drivese_post.generator.rad_ag')
+                    self.connect('generator.t_wr'         , 'drivese_post.generator.t_wr')
+
+                    self.connect('generator.n_s'          , 'drivese_post.generator.n_s')
+                    self.connect('generator.b_st'         , 'drivese_post.generator.b_st')
+                    self.connect('generator.d_s'          , 'drivese_post.generator.d_s')
+                    self.connect('generator.t_ws'         , 'drivese_post.generator.t_ws')
+
+                    self.connect('generator.rho_Copper'   , 'drivese_post.generator.rho_Copper')
+                    self.connect('generator.rho_Fe'       , 'drivese_post.generator.rho_Fe')
+                    self.connect('generator.rho_Fes'      , 'drivese_post.generator.rho_Fes')
+                    self.connect('generator.rho_PM'       , 'drivese_post.generator.rho_PM')
+
+                    self.connect('generator.C_Cu'         , 'drivese_post.generator.C_Cu')
+                    self.connect('generator.C_Fe'         , 'drivese_post.generator.C_Fe')
+                    self.connect('generator.C_Fes'        , 'drivese_post.generator.C_Fes')
+                    self.connect('generator.C_PM'         , 'drivese_post.generator.C_PM')
+
+                    if modeling_options['GeneratorSE']['type'] in ['pmsg_outer']:
+                        self.connect('generator.N_c'          , 'drivese_post.generator.N_c')
+                        self.connect('generator.b'            , 'drivese_post.generator.b')
+                        self.connect('generator.c'            , 'drivese_post.generator.c')
+                        self.connect('generator.E_p'          , 'drivese_post.generator.E_p')
+                        self.connect('generator.h_yr'         , 'drivese_post.generator.h_yr')
+                        self.connect('generator.h_ys'         , 'drivese_post.generator.h_ys')
+                        self.connect('generator.h_sr'         , 'drivese_post.generator.h_sr')
+                        self.connect('generator.h_ss'         , 'drivese_post.generator.h_ss')
+                        self.connect('generator.t_r'          , 'drivese_post.generator.t_r')
+                        self.connect('generator.t_s'          , 'drivese_post.generator.t_s')
+
+                        self.connect('generator.u_allow_pcent', 'drivese_post.generator.u_allow_pcent')
+                        self.connect('generator.y_allow_pcent', 'drivese_post.generator.y_allow_pcent')
+                        self.connect('generator.z_allow_deg'  , 'drivese_post.generator.z_allow_deg')
+                        self.connect('generator.B_tmax'       , 'drivese_post.generator.B_tmax')
+                        self.connect('rp.powercurve.rated_mech', 'drivese_post.generator.P_mech')
+
+                    if modeling_options['GeneratorSE']['type'] in ['eesg','pmsg_arms','pmsg_disc']:
+                        self.connect('generator.tau_p'        , 'drivese_post.generator.tau_p')
+                        self.connect('generator.h_ys'         , 'drivese_post.generator.h_ys')
+                        self.connect('generator.h_yr'         , 'drivese_post.generator.h_yr')
+                        self.connect('generator.b_arm'        , 'drivese_post.generator.b_arm')
+
+                    elif modeling_options['GeneratorSE']['type'] in ['scig','dfig']:
+                        self.connect('generator.B_symax'      , 'drivese_post.generator.B_symax')
+                        self.connect('generator.S_Nmax'      , 'drivese_post.generator.S_Nmax')
+
+                    if modeling_options['WISDEM']['DriveSE']['direct']:
+                        self.connect('nacelle.nose_diameter',             'drivese_post.generator.D_nose', src_indices=[-1])
+                        self.connect('nacelle.lss_diameter',              'drivese_post.generator.D_shaft', src_indices=[0])
+                    else:
+                        self.connect('nacelle.hss_diameter',              'drivese_post.generator.D_shaft', src_indices=[-1])
+
+                else:
+                    self.connect('generator.generator_mass_user', 'drivese_post.generator_mass_user')
+                    self.connect('generator.generator_efficiency_user', 'drivese_post.generator_efficiency_user')
+
+            # Connections to TowerSE
+            if modeling_options['WISDEM']['DriveSE']['flag'] and modeling_options['WISDEM']['TowerSE']['flag']:
+                self.connect('drivese_post.base_F',                'towerse_post.pre.rna_F')
+                self.connect('drivese_post.base_M',                'towerse_post.pre.rna_M')
+                self.connect('drivese_post.rna_I_TT',             'towerse_post.rna_I')
+                self.connect('drivese_post.rna_cm',               'towerse_post.rna_cg')
+                self.connect('drivese_post.rna_mass',             'towerse_post.rna_mass')
                 
-            self.connect('assembly.hub_height',           'towerse_post.wind_reference_height')  # TODO- environment
-            self.connect('tower_grid.foundation_height', 'towerse_post.tower_foundation_height') # TODO- environment
-            self.connect('env.rho_air',                   'towerse_post.rho_air')
-            self.connect('env.mu_air',                    'towerse_post.mu_air')                    
-            self.connect('env.shear_exp',                 'towerse_post.shearExp')                    
-            self.connect('assembly.hub_height',           'towerse_post.hub_height')
-            self.connect('tower.diameter',                'towerse_post.tower_outer_diameter_in')
-            self.connect('tower_grid.height',                  'towerse_post.tower_height')
-            self.connect('tower_grid.s',                       'towerse_post.tower_s')
-            self.connect('tower.layer_thickness',         'towerse_post.tower_layer_thickness')
-            self.connect('tower.outfitting_factor',       'towerse_post.tower_outfitting_factor')
-            self.connect('tower.layer_mat',               'towerse_post.tower_layer_materials')
-            self.connect('materials.name',                'towerse_post.material_names')
-            self.connect('materials.E',                   'towerse_post.E_mat')
-            self.connect('materials.G',                   'towerse_post.G_mat')
-            self.connect('materials.rho',                 'towerse_post.rho_mat')
-            self.connect('materials.sigma_y',             'towerse_post.sigma_y_mat')
-            self.connect('materials.unit_cost',           'towerse_post.unit_cost_mat')
-            self.connect('costs.labor_rate',              'towerse_post.labor_cost_rate')
-            self.connect('costs.painting_rate',           'towerse_post.painting_cost_rate')
-            
-            if modeling_options['flags']['monopile']:
-                self.connect("env.water_depth",                  "towerse_post.water_depth")
-                self.connect('env.rho_water',                    'towerse_post.rho_water')
-                self.connect('env.mu_water',                     'towerse_post.mu_water')                    
-                self.connect('env.G_soil',                       'towerse_post.G_soil')                    
-                self.connect('env.nu_soil',                      'towerse_post.nu_soil')                    
-                self.connect("env.Hsig_wave",                    "towerse_post.Hsig_wave")
-                self.connect("env.Tsig_wave",                    "towerse_post.Tsig_wave")
-                self.connect('monopile.diameter',                'towerse_post.monopile_outer_diameter_in')
-                self.connect("monopile.foundation_height",       "towerse.monopile_foundation_height")
-                self.connect('monopile.height',                  'towerse_post.monopile_height')
-                self.connect('monopile.s',                       'towerse_post.monopile_s')
-                self.connect('monopile.layer_thickness',         'towerse_post.monopile_layer_thickness')
-                self.connect('monopile.layer_mat',               'towerse_post.monopile_layer_materials')
-                self.connect('monopile.outfitting_factor',       'towerse_post.monopile_outfitting_factor')
-                self.connect('monopile.transition_piece_mass',   'towerse_post.transition_piece_mass')
-                self.connect('monopile.transition_piece_cost',   'towerse_post.transition_piece_cost')
-                self.connect('monopile.gravity_foundation_mass', 'towerse_post.gravity_foundation_mass')
+                if modeling_options['Level3']['ROSCO']['flag']:
+                    self.connect('rp.gust.V_gust',               'towerse_post.wind.Uref')
+                    
+                self.connect('assembly.hub_height',           'towerse_post.wind_reference_height')  # TODO- environment
+                self.connect('tower_grid.foundation_height', 'towerse_post.tower_foundation_height') # TODO- environment
+                self.connect('env.rho_air',                   'towerse_post.rho_air')
+                self.connect('env.mu_air',                    'towerse_post.mu_air')                    
+                self.connect('env.shear_exp',                 'towerse_post.shearExp')                    
+                self.connect('assembly.hub_height',           'towerse_post.hub_height')
+                self.connect('tower.diameter',                'towerse_post.tower_outer_diameter_in')
+                self.connect('tower_grid.height',                  'towerse_post.tower_height')
+                self.connect('tower_grid.s',                       'towerse_post.tower_s')
+                self.connect('tower.layer_thickness',         'towerse_post.tower_layer_thickness')
+                self.connect('tower.outfitting_factor',       'towerse_post.tower_outfitting_factor')
+                self.connect('tower.layer_mat',               'towerse_post.tower_layer_materials')
+                self.connect('materials.name',                'towerse_post.material_names')
+                self.connect('materials.E',                   'towerse_post.E_mat')
+                self.connect('materials.G',                   'towerse_post.G_mat')
+                self.connect('materials.rho',                 'towerse_post.rho_mat')
+                self.connect('materials.sigma_y',             'towerse_post.sigma_y_mat')
+                self.connect('materials.unit_cost',           'towerse_post.unit_cost_mat')
+                self.connect('costs.labor_rate',              'towerse_post.labor_cost_rate')
+                self.connect('costs.painting_rate',           'towerse_post.painting_cost_rate')
+                
+                if modeling_options['flags']['monopile']:
+                    self.connect("env.water_depth",                  "towerse_post.water_depth")
+                    self.connect('env.rho_water',                    'towerse_post.rho_water')
+                    self.connect('env.mu_water',                     'towerse_post.mu_water')                    
+                    self.connect('env.G_soil',                       'towerse_post.G_soil')                    
+                    self.connect('env.nu_soil',                      'towerse_post.nu_soil')                    
+                    self.connect("env.Hsig_wave",                    "towerse_post.Hsig_wave")
+                    self.connect("env.Tsig_wave",                    "towerse_post.Tsig_wave")
+                    self.connect('monopile.diameter',                'towerse_post.monopile_outer_diameter_in')
+                    self.connect("monopile.foundation_height",       "towerse.monopile_foundation_height")
+                    self.connect('monopile.height',                  'towerse_post.monopile_height')
+                    self.connect('monopile.s',                       'towerse_post.monopile_s')
+                    self.connect('monopile.layer_thickness',         'towerse_post.monopile_layer_thickness')
+                    self.connect('monopile.layer_mat',               'towerse_post.monopile_layer_materials')
+                    self.connect('monopile.outfitting_factor',       'towerse_post.monopile_outfitting_factor')
+                    self.connect('monopile.transition_piece_mass',   'towerse_post.transition_piece_mass')
+                    self.connect('monopile.transition_piece_cost',   'towerse_post.transition_piece_cost')
+                    self.connect('monopile.gravity_foundation_mass', 'towerse_post.gravity_foundation_mass')
 
-        #self.connect('yield_stress',            'tow.sigma_y') # TODO- materials
-        #self.connect('max_taper_ratio',         'max_taper') # TODO- 
-        #self.connect('min_diameter_thickness_ratio', 'min_d_to_t')
-          
-        
-        
-        # Connections to turbine constraints
-        if modeling_options['WISDEM']['TowerSE']['flag']:
-            self.connect('configuration.rotor_orientation', 'tcons_post.rotor_orientation')
-            self.connect('rlds_post.tip_pos.tip_deflection',     'tcons_post.tip_deflection')
-            self.connect('assembly.rotor_radius',           'tcons_post.Rtip')
-            self.connect('blade.outer_shape_bem.ref_axis',  'tcons_post.ref_axis_blade')
-            self.connect('hub.cone',                        'tcons_post.precone')
-            self.connect('nacelle.uptilt',                  'tcons_post.tilt')
-            self.connect('nacelle.overhang',                'tcons_post.overhang')
-            self.connect('tower.ref_axis',                  'tcons_post.ref_axis_tower')
-            self.connect('tower.diameter',                  'tcons_post.d_full')
+            #self.connect('yield_stress',            'tow.sigma_y') # TODO- materials
+            #self.connect('max_taper_ratio',         'max_taper') # TODO- 
+            #self.connect('min_diameter_thickness_ratio', 'min_d_to_t')
             
-        # Inputs to plantfinancese from wt group
-        if modeling_options['Level3']['flag'] and modeling_options['openfast']['dlc_settings']['run_power_curve'] and modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 2:
-            self.connect('aeroelastic.AEP',     'financese_post.turbine_aep')
-        elif modeling_options['Level3']['ROSCO']['flag']:
-            self.connect('rp.AEP',             'financese_post.turbine_aep')
+            
+            
+            # Connections to turbine constraints
+            if modeling_options['WISDEM']['TowerSE']['flag']:
+                self.connect('configuration.rotor_orientation', 'tcons_post.rotor_orientation')
+                self.connect('rlds_post.tip_pos.tip_deflection',     'tcons_post.tip_deflection')
+                self.connect('assembly.rotor_radius',           'tcons_post.Rtip')
+                self.connect('blade.outer_shape_bem.ref_axis',  'tcons_post.ref_axis_blade')
+                self.connect('hub.cone',                        'tcons_post.precone')
+                self.connect('nacelle.uptilt',                  'tcons_post.tilt')
+                self.connect('nacelle.overhang',                'tcons_post.overhang')
+                self.connect('tower.ref_axis',                  'tcons_post.ref_axis_tower')
+                self.connect('tower.diameter',                  'tcons_post.d_full')
+                
+            # Inputs to plantfinancese from wt group
+            if modeling_options['openfast']['dlc_settings']['run_power_curve'] and modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 2:
+                self.connect('aeroelastic.AEP',     'financese_post.turbine_aep')
+            elif modeling_options['Level3']['ROSCO']['flag']:
+                self.connect('rp.AEP',             'financese_post.turbine_aep')
 
-        self.connect('tcc.turbine_cost_kW',     'financese_post.tcc_per_kW')
-        if modeling_options['WISDEM']['BOS']['flag']:
-            if modeling_options['flags']['monopile'] == True or modeling_options['flags']['floating_platform'] == True:
-                self.connect('orbit.total_capex_kW',    'financese_post.bos_per_kW')
-            else:
-                self.connect('landbosse.bos_capex_kW',  'financese_post.bos_per_kW')
-        # Inputs to plantfinancese from input yaml
-        if modeling_options['flags']['control']:
-            self.connect('configuration.rated_power',     'financese_post.machine_rating')
-            
-        self.connect('costs.turbine_number',    'financese_post.turbine_number')
-        self.connect('costs.opex_per_kW',       'financese_post.opex_per_kW')
-        self.connect('costs.offset_tcc_per_kW', 'financese_post.offset_tcc_per_kW')
-        self.connect('costs.wake_loss_factor',  'financese_post.wake_loss_factor')
-        self.connect('costs.fixed_charge_rate', 'financese_post.fixed_charge_rate')
+            self.connect('tcc.turbine_cost_kW',     'financese_post.tcc_per_kW')
+            if modeling_options['WISDEM']['BOS']['flag']:
+                if modeling_options['flags']['monopile'] == True or modeling_options['flags']['floating_platform'] == True:
+                    self.connect('orbit.total_capex_kW',    'financese_post.bos_per_kW')
+                else:
+                    self.connect('landbosse.bos_capex_kW',  'financese_post.bos_per_kW')
+            # Inputs to plantfinancese from input yaml
+            if modeling_options['flags']['control']:
+                self.connect('configuration.rated_power',     'financese_post.machine_rating')
+                
+            self.connect('costs.turbine_number',    'financese_post.turbine_number')
+            self.connect('costs.opex_per_kW',       'financese_post.opex_per_kW')
+            self.connect('costs.offset_tcc_per_kW', 'financese_post.offset_tcc_per_kW')
+            self.connect('costs.wake_loss_factor',  'financese_post.wake_loss_factor')
+            self.connect('costs.fixed_charge_rate', 'financese_post.fixed_charge_rate')
 
-        # Connections to outputs to screen
-        if modeling_options['Level3']['ROSCO']:
-            if modeling_options['Level3']['flag'] and modeling_options['openfast']['dlc_settings']['run_power_curve'] and modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 2:
-                self.connect('aeroelastic.AEP',     'outputs_2_screen_weis.aep')
-            else:
-                self.connect('rp.AEP',             'outputs_2_screen_weis.aep')
-            self.connect('financese_post.lcoe',          'outputs_2_screen_weis.lcoe')
+            # Connections to outputs to screen
+            if modeling_options['Level3']['ROSCO']['flag']:
+                if modeling_options['openfast']['dlc_settings']['run_power_curve'] and modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 2:
+                    self.connect('aeroelastic.AEP',     'outputs_2_screen_weis.aep')
+                else:
+                    self.connect('rp.AEP',             'outputs_2_screen_weis.aep')
+                self.connect('financese_post.lcoe',          'outputs_2_screen_weis.lcoe')
+                
+            self.connect('re.precomp.blade_mass',  'outputs_2_screen_weis.blade_mass')
+            self.connect('rlds_post.tip_pos.tip_deflection', 'outputs_2_screen_weis.tip_deflection')
             
-        self.connect('re.precomp.blade_mass',  'outputs_2_screen_weis.blade_mass')
-        self.connect('rlds_post.tip_pos.tip_deflection', 'outputs_2_screen_weis.tip_deflection')
-        
-        if modeling_options['Level3']['flag'] and modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 2:
-            self.connect('aeroelastic.DEL_RootMyb',        'outputs_2_screen_weis.DEL_RootMyb')
-            self.connect('aeroelastic.DEL_TwrBsMyt',       'outputs_2_screen_weis.DEL_TwrBsMyt')
-            self.connect('aeroelastic.rotor_overspeed',    'outputs_2_screen_weis.rotor_overspeed')
-            self.connect('tune_rosco_ivc.PC_omega',        'outputs_2_screen_weis.PC_omega')
-            self.connect('tune_rosco_ivc.PC_zeta',         'outputs_2_screen_weis.PC_zeta')
-            self.connect('tune_rosco_ivc.VS_omega',        'outputs_2_screen_weis.VS_omega')
-            self.connect('tune_rosco_ivc.VS_zeta',         'outputs_2_screen_weis.VS_zeta')
-            self.connect('tune_rosco_ivc.Flp_omega',       'outputs_2_screen_weis.Flp_omega')
-            self.connect('tune_rosco_ivc.Flp_zeta',        'outputs_2_screen_weis.Flp_zeta')
-            self.connect('tune_rosco_ivc.IPC_Ki1p',        'outputs_2_screen_weis.IPC_Ki1p')
-            self.connect('dac_ivc.te_flap_end',            'outputs_2_screen_weis.te_flap_end')
+            if modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 2:
+                self.connect('aeroelastic.DEL_RootMyb',        'outputs_2_screen_weis.DEL_RootMyb')
+                self.connect('aeroelastic.DEL_TwrBsMyt',       'outputs_2_screen_weis.DEL_TwrBsMyt')
+                self.connect('aeroelastic.rotor_overspeed',    'outputs_2_screen_weis.rotor_overspeed')
+                self.connect('tune_rosco_ivc.PC_omega',        'outputs_2_screen_weis.PC_omega')
+                self.connect('tune_rosco_ivc.PC_zeta',         'outputs_2_screen_weis.PC_zeta')
+                self.connect('tune_rosco_ivc.VS_omega',        'outputs_2_screen_weis.VS_omega')
+                self.connect('tune_rosco_ivc.VS_zeta',         'outputs_2_screen_weis.VS_zeta')
+                self.connect('tune_rosco_ivc.Flp_omega',       'outputs_2_screen_weis.Flp_omega')
+                self.connect('tune_rosco_ivc.Flp_zeta',        'outputs_2_screen_weis.Flp_zeta')
+                self.connect('tune_rosco_ivc.IPC_Ki1p',        'outputs_2_screen_weis.IPC_Ki1p')
+                self.connect('dac_ivc.te_flap_end',            'outputs_2_screen_weis.te_flap_end')

--- a/weis/inputs/modeling_schema.yaml
+++ b/weis/inputs/modeling_schema.yaml
@@ -2371,6 +2371,24 @@ properties:
         type: object
         default: {}
         properties:
+            analysis_settings:
+                type: object
+                default: {}
+                properties:
+                    Analysis_Level:
+                        type: integer
+                        default: 2
+                        enum: [1,2]
+                        description: Flag to set the call to OpenFAST. 1 - generate OpenFAST model, 2 - generate and run OpenFAST model
+                    generate_af_coords: 
+                        type: boolean
+                        default: False
+                        description: Flag to write airfoil coordinates out or not
+                    debug_level:
+                        type: integer
+                        default: 2
+                        enum: [2]
+                        description: Flag to set the debug level, do not change
             file_management:
                 type: object
                 default: {}


### PR DESCRIPTION
This PR:
1) adds the analysis_settings to the modeling_options schema. These flags may eventually move away, but for now it's good to include in the schema. two of the five sub-flags were also removed as unnecessary (update_hub_nacelle and update_tower)
2) makes sure that analysis level can only take values 1 and 2 (0 is no longer allowed)
3) when Level3 flag is turned off, wisdem runs
4) fixes a bug in inflow_wind initializing the ref_length for shear correctly
5) removes some outdated warnings for inflowwind
6) adds a column for up flow angle in the .wnd files (coherent DLCs). up flow is initialized at 0 deg (I'm checking this value) in the standards