### PR TITLE
B/mtd

### DIFF
--- a/examples/02_control_opt/analysis_options.yaml
+++ b/examples/02_control_opt/analysis_options.yaml
@@ -99,7 +99,7 @@ constraints:
       max:  3500.e-6  # Value of maximum strains [-]
     tip_deflection:
       flag: False     # Constraint that maximum tip deflection cannot exceed 70% of tower clearance. Only for upwind rotors
-      ratio: 0.8
+      margin: 1.4175
     rail_transport:
       flag: False
       8_axle: False

--- a/examples/05_IEA-3.4-130-RWT/analysis_options.yaml
+++ b/examples/05_IEA-3.4-130-RWT/analysis_options.yaml
@@ -99,7 +99,7 @@ constraints:
       max:  3500.e-6  # Value of maximum strains [-]
     tip_deflection:
       flag: False     # Constraint that maximum tip deflection cannot exceed 70% of tower clearance. Only for upwind rotors
-      ratio: 0.8
+      margin: 1.4175
     rail_transport:
       flag: False
       8_axle: False

--- a/examples/06_IEA-15-240-RWT/analysis_options.yaml
+++ b/examples/06_IEA-15-240-RWT/analysis_options.yaml
@@ -99,7 +99,7 @@ constraints:
       max:  3500.e-6  # Value of maximum strains [-]
     tip_deflection:
       flag: False     # Constraint that maximum tip deflection cannot exceed 70% of tower clearance. Only for upwind rotors
-      ratio: 0.8
+      margin: 1.4175
     rail_transport:
       flag: False
       8_axle: False

--- a/examples/07_te_flaps/analysis_options.yaml
+++ b/examples/07_te_flaps/analysis_options.yaml
@@ -99,7 +99,7 @@ constraints:
       max:  3500.e-6  # Value of maximum strains [-]
     tip_deflection:
       flag: True     # Constraint that maximum tip deflection cannot exceed 70% of tower clearance. Only for upwind rotors
-      ratio: 0.8
+      margin: 1.4175
     rail_transport:
       flag: False
       8_axle: False

--- a/weis/glue_code/gc_PoseOptimization.py
+++ b/weis/glue_code/gc_PoseOptimization.py
@@ -254,7 +254,7 @@ class PoseOptimization(object):
 
         if blade_constraints['tip_deflection']['flag']:
             if self.blade_opt['structure']['spar_cap_ss']['flag'] or self.blade_opt['structure']['spar_cap_ps']['flag']:
-                wt_opt.model.add_constraint('tcons.tip_deflection_ratio', upper=blade_constraints['tip_deflection']['ratio'])
+                wt_opt.model.add_constraint('tcons.tip_deflection_ratio', upper=1.0)
             else:
                 print('WARNING: the tip deflection is set to be constrained, but spar caps thickness is not an active design variable. The constraint is not enforced.')
 
@@ -408,6 +408,7 @@ class PoseOptimization(object):
         wt_opt['rs.constr.max_strainU_spar'] = blade_constraints['strains_spar_cap_ss']['max']
         wt_opt['rs.constr.max_strainL_spar'] = blade_constraints['strains_spar_cap_ps']['max']
         wt_opt['stall_check.stall_margin'] = blade_constraints['stall']['margin'] * 180. / np.pi
+        wt_opt["tcons.max_allowable_td_ratio"] = blade_constr["tip_deflection"]["margin"]
         
         return wt_opt
 

--- a/weis/glue_code/gc_PoseOptimization.py
+++ b/weis/glue_code/gc_PoseOptimization.py
@@ -401,13 +401,13 @@ class PoseOptimization(object):
             if max(wt_opt['blade.opt_var.twist_opt_gain']) > 1. or min(wt_opt['blade.opt_var.twist_opt_gain']) < 0.:
                 print('Warning: the initial twist violates the upper or lower bounds of the twist design variables.')
                 
-        blade_constraints = self.opt['constraints']['blade']
+        blade_constr = self.opt['constraints']['blade']
         wt_opt['blade.opt_var.s_opt_chord']  = np.linspace(0., 1., self.blade_opt['aero_shape']['chord']['n_opt'])
         wt_opt['blade.ps.s_opt_spar_cap_ss'] = np.linspace(0., 1., self.blade_opt['structure']['spar_cap_ss']['n_opt'])
         wt_opt['blade.ps.s_opt_spar_cap_ps'] = np.linspace(0., 1., self.blade_opt['structure']['spar_cap_ps']['n_opt'])
-        wt_opt['rs.constr.max_strainU_spar'] = blade_constraints['strains_spar_cap_ss']['max']
-        wt_opt['rs.constr.max_strainL_spar'] = blade_constraints['strains_spar_cap_ps']['max']
-        wt_opt['stall_check.stall_margin'] = blade_constraints['stall']['margin'] * 180. / np.pi
+        wt_opt['rs.constr.max_strainU_spar'] = blade_constr['strains_spar_cap_ss']['max']
+        wt_opt['rs.constr.max_strainL_spar'] = blade_constr['strains_spar_cap_ps']['max']
+        wt_opt['stall_check.stall_margin'] = blade_constr['stall']['margin'] * 180. / np.pi
         wt_opt["tcons.max_allowable_td_ratio"] = blade_constr["tip_deflection"]["margin"]
         
         return wt_opt


### PR DESCRIPTION
Small PR to update WEIS and use "margin" to constraint tip deflection and not the old quantity "ratio". WISDEM already does it, but the glue_code in WEIS hadn't been updated. 