### PR TITLE
Bring ROSCO_toolbox and ROSCO subtrees up-to-date

### DIFF
--- a/ROSCO/src/ControllerBlocks.f90
+++ b/ROSCO/src/ControllerBlocks.f90
@@ -176,6 +176,7 @@ CONTAINS
                 xh = RESHAPE((/om_r, v_t, v_m/),(/3,1/))
                 P = RESHAPE((/0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 1.0/),(/3,3/))
                 K = RESHAPE((/0.0,0.0,0.0/),(/3,1/))
+                Cp_op   = 0.25  ! initialize so debug output doesn't give *****
                 
             ELSE
                 ! Find estimated operating Cp and system pole

--- a/ROSCO/src/ReadSetParameters.f90
+++ b/ROSCO/src/ReadSetParameters.f90
@@ -629,7 +629,7 @@ CONTAINS
         READ(UnPerfParameters, *) 
         ALLOCATE(PerfData%Cq_mat(CntrPar%PerfTableSize(1),CntrPar%PerfTableSize(2)))
         DO i = 1,CntrPar%PerfTableSize(2)
-            READ(UnPerfParameters, *) PerfData%Ct_mat(i,:) ! Read Cq table
+            READ(UnPerfParameters, *) PerfData%Cq_mat(i,:) ! Read Cq table
         END DO
     
     END SUBROUTINE ReadCpFile

--- a/ROSCO_toolbox/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/ROSCO_toolbox/controller.py
@@ -303,7 +303,8 @@ class Controller():
         # --- Floating feedback term ---
         if self.Fl_Mode == 1: # Floating feedback
             Kp_float = (dtau_dv/dtau_dbeta) * turbine.TowerHt * Ng 
-            self.Kp_float = Kp_float[len(v_below_rated)]
+            f_kp     = interpolate.interp1d(v,Kp_float)
+            self.Kp_float = f_kp(turbine.v_rated + 0.5)   # get Kp at v_rated + 0.5 m/s
             # Turn on the notch filter if floating
             self.F_NotchType = 2
             


### PR DESCRIPTION
Minor Changes:
- Because of the way the wind speed was indexed in ROSCO_toolbox, there could be very high floating feedback gains when tuning ROSCO; this is fixed.
- Bug fixes in ROSCO related to reading Cp/Ct/Cq tables and the debug output, which made it hard to read ROSCO output files.  These should not affect results.