### PR TITLE
Pinning openmpi version

### DIFF
--- a/.github/workflows/CI_WEIS.yml
+++ b/.github/workflows/CI_WEIS.yml
@@ -31,7 +31,7 @@ jobs:
         shell: pwsh # putting in a shell command makes for compile linking problems later
         # (if you use the shell here, cannot use 'compiler' package, but mpi only seems to work with it)
         run: |
-          conda install -y petsc4py mpi4py 
+          conda install -y petsc4py mpi4py openmpi==4.0.5
           python -c "import platform; print(platform.node())"
 
       # Install dependencies of WISDEM specific to windows

--- a/.github/workflows/run_exhaustive_examples.yml
+++ b/.github/workflows/run_exhaustive_examples.yml
@@ -31,7 +31,7 @@ jobs:
         shell: pwsh # putting in a shell command makes for compile linking problems later
         # (if you use the shell here, cannot use 'compiler' package, but mpi only seems to work with it)
         run: |
-          conda install -y petsc4py mpi4py 
+          conda install -y petsc4py mpi4py openmpi==4.0.5
           python -c "import platform; print(platform.node())"
 
       # Install dependencies of WISDEM specific to windows


### PR DESCRIPTION
This is just for GH actions testing until all packages catch up to the newer OpenMPI version