### PR TITLE
changes to external codes to get library version working

### DIFF
--- a/OpenFAST/glue-codes/python/openfast_library.py
+++ b/OpenFAST/glue-codes/python/openfast_library.py
@@ -8,6 +8,8 @@ from ctypes import (
     c_char,
     c_bool
 )
+import _ctypes
+import platform
 import numpy as np
 
 
@@ -203,3 +205,10 @@ class FastLibAPI(CDLL):
         output_channel_names = self._channel_names.value.split()
         output_channel_names = [n.decode('UTF-8') for n in output_channel_names]        
         return output_channel_names
+
+    def close_library(self):
+        mactype = platform.system().lower()
+        if mactype in ["linux", "linux2", "darwin"]:
+            _ctypes.dlclose(self._handle)
+        elif mactype in ["win32", "cygwin"]:
+            _ctypes.FreeLibrary(self._handle)

--- a/ROSCO/src/ReadSetParameters.f90
+++ b/ROSCO/src/ReadSetParameters.f90
@@ -42,6 +42,28 @@ CONTAINS
        
 
         OPEN(unit=UnControllerParameters, file=accINFILE(1), status='old', action='read')
+
+
+        IF (ALLOCATED(CntrPar%F_NotchBetaNumDen))  THEN
+           DEALLOCATE(CntrPar%F_NotchBetaNumDen)
+           DEALLOCATE(CntrPar%PC_GS_angles)
+           DEALLOCATE(CntrPar%PC_GS_KP)
+           DEALLOCATE(CntrPar%PC_GS_KI)
+           DEALLOCATE(CntrPar%PC_GS_KD)
+           DEALLOCATE(CntrPar%PC_GS_TF)
+           DEALLOCATE(CntrPar%IPC_KI)
+           DEALLOCATE(CntrPar%IPC_aziOffset)
+           DEALLOCATE(CntrPar%VS_KP)
+           DEALLOCATE(CntrPar%VS_KI)
+           DEALLOCATE(CntrPar%WE_CP)
+           DEALLOCATE(CntrPar%PerfTableSize)
+           DEALLOCATE(CntrPar%WE_FOPoles_v)
+           DEALLOCATE(CntrPar%WE_FOPoles)
+           DEALLOCATE(CntrPar%Y_IPC_KP)
+           DEALLOCATE(CntrPar%Y_IPC_KI)
+           DEALLOCATE(CntrPar%PS_WindSpeeds)
+           DEALLOCATE(CntrPar%PS_BldPitchMin)
+        END IF
         
         !----------------------- HEADER ------------------------
         READ(UnControllerParameters, *)
@@ -593,6 +615,14 @@ CONTAINS
         ! Local variables
         INTEGER(4)                  :: i ! iteration index
         OPEN(unit=UnPerfParameters, file=TRIM(CntrPar%PerfFileName), status='old', action='read') ! Should put input file into DISCON.IN
+
+        IF (ALLOCATED(PerfData%Beta_vec))  THEN
+           DEALLOCATE(PerfData%Beta_vec)
+           DEALLOCATE(PerfData%TSR_vec)
+           DEALLOCATE(PerfData%Cp_mat)
+           DEALLOCATE(PerfData%Ct_mat)
+           DEALLOCATE(PerfData%Cq_mat)
+        END IF
         
         ! ----------------------- Axis Definitions ------------------------
         READ(UnPerfParameters, *)

--- a/pCrunch/pCrunch/analysis.py
+++ b/pCrunch/pCrunch/analysis.py
@@ -398,13 +398,13 @@ class PowerProduction:
             list containing probabilities per wind speed bin
         """
 
-        if self.turbine_class == 1:
+        if self.turbine_class in [1,'I']:
             Vavg = 50 * 0.2
 
-        elif self.turbine_class == 2:
+        elif self.turbine_class in [2,'II']:
             Vavg = 42.5 * 0.2
 
-        elif self.turbine_class == 3:
+        elif self.turbine_class in [3,'III']:
             Vavg = 37.5 * 0.2
 
         # Define parameters

--- a/weis/aeroelasticse/runFAST_pywrapper.py
+++ b/weis/aeroelasticse/runFAST_pywrapper.py
@@ -32,7 +32,7 @@ if mactype == "linux" or mactype == "linux2":
     libext = ".so"
 elif mactype == "darwin":
     libext = '.dylib'
-    os.environ['DYLD_FALLBACK_LIBRARY_PATH'] = lib_dir
+    #os.environ['DYLD_FALLBACK_LIBRARY_PATH'] = lib_dir
 elif mactype == "win32":
     libext = '.dll'
 elif mactype == "cygwin":
@@ -187,6 +187,7 @@ class runFAST_pywrapper(object):
             #     "channel": np.array([]),
             # }
             output_dict[channel] = openfastlib.output_values[:,i]
+        openfastlib.close_library()
 
         output = OpenFASTOutput.from_dict(output_dict, self.FAST_namingOut, magnitude_channels=magnitude_channels)
         case_name, sum_stats, extremes, dels = la._process_output(output)

--- a/weis/aeroelasticse/runFAST_pywrapper.py
+++ b/weis/aeroelasticse/runFAST_pywrapper.py
@@ -140,7 +140,7 @@ class runFAST_pywrapper(object):
                 reader.execute()
         
             # Initialize writer variables with input model
-            writer.fst_vt = reader.fst_vt
+            writer.fst_vt = self.fst_vt = reader.fst_vt
         else:
             writer.fst_vt = self.fst_vt
         writer.FAST_runDirectory = self.FAST_runDirectory

--- a/weis/test/test_aeroelasticse/test_DLC.py
+++ b/weis/test/test_aeroelasticse/test_DLC.py
@@ -18,6 +18,8 @@ from weis.aeroelasticse.runFAST_pywrapper import (
 )
 from weis.test.utils import compare_regression_values
 
+this_file_dir = os.path.dirname(os.path.realpath(__file__))
+
 
 class TestDLC(unittest.TestCase):
     def test_run(self):
@@ -265,7 +267,6 @@ class TestDLC(unittest.TestCase):
             "Wind1VelZ",
         ]
 
-        this_file_dir = os.path.dirname(os.path.realpath(__file__))
         compare_regression_values(
             out,
             "DLC_regression_values_1.pkl",


### PR DESCRIPTION
These changes get the python wrapper branch working on my computer, but I don't understand them or why they are necessary in the first place.  They also should all originate in the source code of the external projects that y'all own.  Ideally, this PR is cancelled and all of the changes are git subtree-ed into place instead.

@JakeNunemaker : for pCrunch, I had to just make a few minor syntax issues to get through some errors

@rafmudaf : The ED time init error that popped up is a mystery to me.  It only happened once the AD changes were brought in in @ptrbortolotti 's recent PR.  Since it happens on the second run of a batch, it smells like something isn't getting properly deallocated.  I got around it by forcibly unloading the shared library object at the end of each individual OpenFAST call.  Ideally we find the underlying culprit and this is no longer necessary.  For now though, please review and see if you can implement the changes in your fork.

@nikhar-abbas and @dzalkind : The ROSCO initialization errors were also happening in the second run of a batch call to OpenFAST. I am not sure why the ROSCO libdiscon is not unloaded as OpenFAST is closed down, but I think this is due to some sort of the way it is called from OpenFAST.  In ROSCO, I added some `IF Allocated(x) THEN Deallocate(x) ENDIF` statements in the initialization for ROSCO to play nice with this library version of OpenFAST.   Please review my changes and see if they are okay to incorporate into ROSCO.  This was definitely a hack on my part.