### PR TITLE
Td from of

### DIFF
--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -1216,7 +1216,7 @@ class FASTLoadCases(ExplicitComponent):
             tip_max_chan   = "TipDxc3"
             bld_pitch_chan = "BldPitch3"
 
-        outputs["max_TipDxc"] = sum_stats[tip_max_chan]['max']
+        outputs["max_TipDxc"] = np.max(sum_stats[tip_max_chan]['max'])
         # Return spanwise forces at instance of largest deflection
         Fx = [extreme_table[tip_max_chan][np.argmax(sum_stats[tip_max_chan]['max'])][var] for var in blade_chans_Fx]
         Fy = [extreme_table[tip_max_chan][np.argmax(sum_stats[tip_max_chan]['max'])][var] for var in blade_chans_Fy]

--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -307,6 +307,7 @@ class FASTLoadCases(ExplicitComponent):
         self.add_output('DEL_RootMyb', val=0.0,            units='N*m',  desc='damage equivalent load of blade root flap bending moment in out-of-plane direction')
         self.add_output('DEL_TwrBsMyt',val=0.0,            units='N*m',  desc='damage equivalent load of tower base bending moment in fore-aft direction')
         self.add_output('flp1_std',    val=0.0,            units='deg',  desc='standard deviation of trailing-edge flap angle')
+        self.add_output('max_TipDxc',  val=0.0,            units='m',    desc='Maximum of channel TipDxc, i.e. out of plane tip deflection. For upwind rotors, the max value is tower the tower')
 
         self.add_output('V_out',       val=np.zeros(n_OF), units='m/s',  desc='wind vector')
         self.add_output('P_out',       val=np.zeros(n_OF), units='W',    desc='rotor electrical power')
@@ -1214,7 +1215,8 @@ class FASTLoadCases(ExplicitComponent):
             blade_chans_Fy = ["B3N1Fy", "B3N2Fy", "B3N3Fy", "B3N4Fy", "B3N5Fy", "B3N6Fy", "B3N7Fy", "B3N8Fy", "B3N9Fy"]
             tip_max_chan   = "TipDxc3"
             bld_pitch_chan = "BldPitch3"
-            
+
+        outputs["max_TipDxc"] = sum_stats[tip_max_chan]['max']
         # Return spanwise forces at instance of largest deflection
         Fx = [extreme_table[tip_max_chan][np.argmax(sum_stats[tip_max_chan]['max'])][var] for var in blade_chans_Fx]
         Fy = [extreme_table[tip_max_chan][np.argmax(sum_stats[tip_max_chan]['max'])][var] for var in blade_chans_Fy]

--- a/weis/glue_code/glue_code.py
+++ b/weis/glue_code/glue_code.py
@@ -631,7 +631,7 @@ class WindPark(om.Group):
             # Connections to turbine constraints
             if modeling_options['WISDEM']['TowerSE']['flag']:
                 self.connect('configuration.rotor_orientation', 'tcons_post.rotor_orientation')
-                self.connect('rlds_post.tip_pos.tip_deflection',     'tcons_post.tip_deflection')
+                self.connect('aeroelastic.max_TipDxc',          'tcons_post.tip_deflection')
                 self.connect('assembly.rotor_radius',           'tcons_post.Rtip')
                 self.connect('blade.outer_shape_bem.ref_axis',  'tcons_post.ref_axis_blade')
                 self.connect('hub.cone',                        'tcons_post.precone')
@@ -671,7 +671,7 @@ class WindPark(om.Group):
                 self.connect('financese_post.lcoe',          'outputs_2_screen_weis.lcoe')
                 
             self.connect('re.precomp.blade_mass',  'outputs_2_screen_weis.blade_mass')
-            self.connect('rlds_post.tip_pos.tip_deflection', 'outputs_2_screen_weis.tip_deflection')
+            self.connect('aeroelastic.max_TipDxc', 'outputs_2_screen_weis.tip_deflection')
             
             if modeling_options['openfast']['analysis_settings']['Analysis_Level'] == 2:
                 self.connect('aeroelastic.DEL_RootMyb',        'outputs_2_screen_weis.DEL_RootMyb')


### PR DESCRIPTION
The tip deflection is no longer taken from rotorse and its loads that come from openfast, but rather extracted directly from elastodyn. 

We can discuss if this change goes in the right direction.

## Purpose
Nikhar observed some significant discrepancies between the deflections from ED and the "matching" deflections computed by rotorse for those loads.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation