### PR TITLE
Subtelty of platform name on windows

### DIFF
--- a/weis/aeroelasticse/runFAST_pywrapper.py
+++ b/weis/aeroelasticse/runFAST_pywrapper.py
@@ -32,7 +32,7 @@ if mactype == "linux" or mactype == "linux2":
     libext = ".so"
 elif mactype == "darwin":
     libext = '.dylib'
-elif mactype == "win32":
+elif mactype == "win32" or mactype == "windows": #NOTE: platform.system()='Windows', sys.platform='win32'
     libext = '.dll'
 elif mactype == "cygwin":
     libext = ".dll"


### PR DESCRIPTION
The machine type was not correct. The alternative would be to use sys.platform in that case.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
```
>>> platform.system()
'Windows'
>>> sys.platform
'win32'
```
