### PR TITLE
Set the OpenFAST Library path in test script

### DIFF
--- a/weis/aeroelasticse/test/test_OF_utils.py
+++ b/weis/aeroelasticse/test/test_OF_utils.py
@@ -58,6 +58,7 @@ class TestOFutils(unittest.TestCase):
 
         fast_wr = runFAST_pywrapper()
         fast_wr.FAST_exe =  None # osp.join(weis_dir,'local/bin/openfast')   # Path to executable
+        fast_wr.FAST_lib = osp.join(weis_dir, 'local', 'lib', 'libopenfastlib'+libext)
         fast_wr.FAST_InputFile = self.fast.FAST_InputFile   # FAST input file (ext=.fst)
         fast_wr.FAST_directory = self.fast.FAST_directory   # Path to fst directory files
         fast_wr.FAST_runDirectory = self.fast.FAST_runDirectory   # Path to fst directory files


### PR DESCRIPTION
## Purpose
This pull request fixes the configuration for one of the included tests in aeroelasticse. The OpenFAST Python interface was used but the path to the library file was not set.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
To test this, simply run the script at `WEIS/weis/aeroelasticse/test/test_OF_utils.py`.
As mentioned in #132, this was resulting in an error about a missing symbol. It not proceeds past this and errors on finding the DISCON controller:

```
 Running ServoDyn Interface for Bladed Controllers (using GNU Fortran for Linux, ).
E
======================================================================
ERROR: testWrapper (__main__.TestOFutils)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_OF_utils.py", line 66, in testWrapper
    fast_wr.execute()
  File "/home/WEIS/weis/aeroelasticse/runFAST_pywrapper.py", line 175, in execute
    openfastlib.fast_run()
  File "/home/WEIS/OpenFAST/glue-codes/python/openfast_library.py", line 207, in fast_run
    self.fast_init()
  File "/home/WEIS/OpenFAST/glue-codes/python/openfast_library.py", line 137, in fast_init
    raise RuntimeError(f"Error {_error_status.value}: {_error_message.value}")
RuntimeError: Error 4: b'FAST_InitializeAll:SrvD_Init:BladedInterface_Init:The dynamic library /home/WEIS/local/lib/libdiscon.dylib could not be loaded. Check that the file exists in the specified location and that it is compiled for 64-bit applications.'
```

## Checklist

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation