### PR TITLE
Unique seeds

### DIFF
--- a/examples/05_IEA-3.4-130-RWT/modeling_options.yaml
+++ b/examples/05_IEA-3.4-130-RWT/modeling_options.yaml
@@ -61,7 +61,7 @@ DLC_driver:
     DLCs: # Currently supported IEC 1.1, 1.3, 1.4, 1.5, 5.1, 6.1, 6.3, or define a Custom one
         - DLC: "1.1"
           ws_bin_size: 5
-          n_seeds: 1
+          n_seeds: 2
           analysis_time: 5.
           transient_time: 5.
           #wind_speed: [3., 5., 7., 9., 11., 13., 15., 17., 19., 21., 23., 25.]

--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -1393,7 +1393,8 @@ class FASTLoadCases(ExplicitComponent):
         hub_height = float(inputs['hub_height'])
         rotorD = float(inputs['Rtip'])*2.
         PLExp = float(inputs['shearExp'])
-        dlc_generator = DLCGenerator(cut_in, cut_out, rated, ws_class, wt_class)
+        fix_wind_seeds = modopt['DLC_driver']['fix_wind_seeds']
+        dlc_generator = DLCGenerator(cut_in, cut_out, rated, ws_class, wt_class, fix_wind_seeds)
         # Generate cases from user inputs
         for i_DLC in range(len(DLCs)):
             DLCopt = DLCs[i_DLC]

--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -119,7 +119,7 @@ class FASTLoadCases(ExplicitComponent):
         n_pc         = int(rotorse_options['n_pc'])
 
         # DLC options
-        n_OF_dlc11 = modopt['DLC_driver']['n_cases_dlc11']
+        n_ws_dlc11 = modopt['DLC_driver']['n_ws_dlc11']
 
         # OpenFAST options
         OFmgmt = modopt['DLC_driver']['openfast_file_management']
@@ -350,11 +350,11 @@ class FASTLoadCases(ExplicitComponent):
             self.add_discrete_input("node_names", val=[""] * n_nodes)
 
         # Rotor power outputs
-        self.add_output('V_out', val=np.zeros(n_OF_dlc11), units='m/s', desc='wind speed vector from the OF simulations')
-        self.add_output('P_out', val=np.zeros(n_OF_dlc11), units='W', desc='rotor electrical power')
-        self.add_output('Cp_out', val=np.zeros(n_OF_dlc11), desc='rotor aero power coefficient')
-        self.add_output('Omega_out', val=np.zeros(n_OF_dlc11), units='rpm', desc='rotation speeds to run')
-        self.add_output('pitch_out', val=np.zeros(n_OF_dlc11), units='deg', desc='pitch angles to run')
+        self.add_output('V_out', val=np.zeros(n_ws_dlc11), units='m/s', desc='wind speed vector from the OF simulations')
+        self.add_output('P_out', val=np.zeros(n_ws_dlc11), units='W', desc='rotor electrical power')
+        self.add_output('Cp_out', val=np.zeros(n_ws_dlc11), desc='rotor aero power coefficient')
+        self.add_output('Omega_out', val=np.zeros(n_ws_dlc11), units='rpm', desc='rotation speeds to run')
+        self.add_output('pitch_out', val=np.zeros(n_ws_dlc11), units='deg', desc='pitch angles to run')
         self.add_output('AEP', val=0.0, units='kW*h', desc='annual energy production reconstructed from the openfast simulations')
 
         self.add_output('My_std',      val=0.0,            units='N*m',  desc='standard deviation of blade root flap bending moment in out-of-plane direction')

--- a/weis/dlc_driver/dlc_generator.py
+++ b/weis/dlc_driver/dlc_generator.py
@@ -75,13 +75,14 @@ class DLCGenerator(object):
                 
         return wind_speeds
 
-    def get_wind_seeds(self, options, n_wind_speeds):
+    def get_wind_seeds(self, options, wind_speeds):
         if len(options['wind_seed']) > 0:
             wind_seeds = np.array( [int(m) for m in options['wind_seed']] )
         else:
-            wind_seeds = self.rng.integers(2147483648, size=options['n_seeds']*n_wind_speeds, dtype=int)
+            wind_seeds = self.rng.integers(2147483648, size=options['n_seeds']*len(wind_speeds), dtype=int)
+            wind_speeds = np.repeat(wind_speeds, options['n_seeds'])
 
-        return wind_seeds
+        return wind_speeds, wind_seeds
 
     def get_wind_heading(self, options):
         if len(options['wind_heading']) > 0:
@@ -126,8 +127,8 @@ class DLCGenerator(object):
         return probabilities
 
     def get_metocean(self, options):
-        wind_speeds = self.get_wind_speeds(options)
-        wind_seeds = self.get_wind_seeds(options, len(wind_speeds))
+        wind_speeds_indiv = self.get_wind_speeds(options)
+        wind_speeds, wind_seeds = self.get_wind_seeds(options, wind_speeds_indiv)
         wind_heading = self.get_wind_heading(options)
         wave_Hs = self.get_wave_Hs(options)
         wave_Tp = self.get_wave_Tp(options)
@@ -524,7 +525,8 @@ class DLCGenerator(object):
         wind_speeds = np.arange(self.ws_cut_in, 0.7 * self.V_ref, options['ws_bin_size'])
         if wind_speeds[-1] != self.V_ref:
             wind_speeds = np.append(wind_speeds, self.V_ref)
-        wind_seeds = self.get_wind_seeds(options, len(wind_speeds))
+        wind_speeds, wind_seeds = self.get_wind_seeds(options, wind_speeds)
+        wind_speeds = np.repeat(wind_speeds, options['n_seeds'])
         _, _, wind_heading, wave_Hs, wave_Tp, wave_gamma, wave_heading, _ = self.get_metocean(options)
         # Counter for wind seed
         i_WiSe=0

--- a/weis/dlc_driver/dlc_generator.py
+++ b/weis/dlc_driver/dlc_generator.py
@@ -219,7 +219,7 @@ class DLCGenerator(object):
             if len(wave_heading)>1:
                 i_WaH+=1
                 
-        self.n_cases_dlc11 = len(wind_speeds)
+        self.n_ws_dlc11 = len(np.unique(wind_speeds))
     
     def generate_1p2(self, options):
         # Power production normal turbulence model - fatigue loads

--- a/weis/dlc_driver/dlc_generator.py
+++ b/weis/dlc_driver/dlc_generator.py
@@ -72,11 +72,11 @@ class DLCGenerator(object):
                 
         return wind_speeds
 
-    def get_wind_seeds(self, options):
+    def get_wind_seeds(self, options, n_wind_speeds):
         if len(options['wind_seed']) > 0:
             wind_seeds = np.array( [int(m) for m in options['wind_seed']] )
         else:
-            wind_seeds = self.rng.integers(2147483648, size=options['n_seeds'], dtype=int)
+            wind_seeds = self.rng.integers(2147483648, size=options['n_seeds']*n_wind_speeds, dtype=int)
 
         return wind_seeds
 
@@ -124,7 +124,7 @@ class DLCGenerator(object):
 
     def get_metocean(self, options):
         wind_speeds = self.get_wind_speeds(options)
-        wind_seeds = self.get_wind_seeds(options)
+        wind_seeds = self.get_wind_seeds(options, len(wind_speeds))
         wind_heading = self.get_wind_heading(options)
         wave_Hs = self.get_wave_Hs(options)
         wave_Tp = self.get_wave_Tp(options)
@@ -132,6 +132,8 @@ class DLCGenerator(object):
         wave_heading = self.get_wave_heading(options)
         probabilities = self.get_probabilities(options)
 
+        if len(wind_seeds) > 1 and len(wind_seeds) != len(wind_speeds):
+            raise Exception("The vector of wind_seeds must have either length=1 or the same length of wind speeds")
         if len(wind_heading) > 1 and len(wind_heading) != len(wind_speeds):
             raise Exception("The vector of wind_heading must have either length=1 or the same length of wind speeds")
         if len(wave_Hs) > 1 and len(wave_Hs) != len(wind_speeds):
@@ -175,6 +177,8 @@ class DLCGenerator(object):
     def generate_1p1(self, options):
         # Power production normal turbulence model - ultimate loads
         wind_speeds, wind_seeds, wind_heading, wave_Hs, wave_Tp, wave_gamma, wave_heading, _ = self.get_metocean(options)        
+        # Counter for wind seed
+        i_WiSe=0
         # Counters for wave conditions
         i_Hs=0
         i_Tp=0
@@ -182,39 +186,42 @@ class DLCGenerator(object):
         i_WG=0
         i_WaH=0
         for ws in wind_speeds:
-            for seed in wind_seeds:
-                idlc = DLCInstance(options=options)
-                idlc.URef = ws
-                idlc.RandSeed1 = seed
-                idlc.wind_heading = wind_heading[i_WiH]
-                idlc.wave_height = wave_Hs[i_Hs]
-                idlc.wave_period = wave_Tp[i_Tp]
-                idlc.wave_gamma = wave_gamma[i_WG]
-                idlc.wave_heading = wave_heading[i_WaH]
-                idlc.turbulent_wind = True
-                idlc.label = '1.1'
-                if options['analysis_time'] > 0:
-                    idlc.analysis_time = options['analysis_time']
-                if options['transient_time'] > 0:
-                    idlc.transient_time = options['transient_time']
-                idlc.PSF = 1.2 * 1.25
-                self.cases.append(idlc)
-                if len(wind_heading)>1:
-                    i_WiH+=1
-                if len(wave_Hs)>1:
-                    i_Hs+=1
-                if len(wave_Tp)>1:
-                    i_Tp+=1
-                if len(wave_gamma)>1:
-                    i_WG+=1
-                if len(wave_heading)>1:
-                    i_WaH+=1
+            idlc = DLCInstance(options=options)
+            idlc.URef = ws
+            idlc.RandSeed1 = wind_seeds[i_WiSe]
+            idlc.wind_heading = wind_heading[i_WiH]
+            idlc.wave_height = wave_Hs[i_Hs]
+            idlc.wave_period = wave_Tp[i_Tp]
+            idlc.wave_gamma = wave_gamma[i_WG]
+            idlc.wave_heading = wave_heading[i_WaH]
+            idlc.turbulent_wind = True
+            idlc.label = '1.1'
+            if options['analysis_time'] > 0:
+                idlc.analysis_time = options['analysis_time']
+            if options['transient_time'] > 0:
+                idlc.transient_time = options['transient_time']
+            idlc.PSF = 1.2 * 1.25
+            self.cases.append(idlc)
+            if len(wind_seeds)>1:
+                i_WiSe+=1
+            if len(wind_heading)>1:
+                i_WiH+=1
+            if len(wave_Hs)>1:
+                i_Hs+=1
+            if len(wave_Tp)>1:
+                i_Tp+=1
+            if len(wave_gamma)>1:
+                i_WG+=1
+            if len(wave_heading)>1:
+                i_WaH+=1
                 
-        self.n_cases_dlc11 = len(wind_speeds)*len(wind_seeds)
+        self.n_cases_dlc11 = len(wind_speeds)
     
     def generate_1p2(self, options):
         # Power production normal turbulence model - fatigue loads
         wind_speeds, wind_seeds, wind_heading, wave_Hs, wave_Tp, wave_gamma, wave_heading, probabilities = self.get_metocean(options)
+        # Counter for wind seed
+        i_WiSe=0
         # Counters for wave conditions
         i_Hs=0
         i_Tp=0
@@ -222,38 +229,41 @@ class DLCGenerator(object):
         i_WG=0
         i_WaH=0
         for ws in wind_speeds:
-            for seed in wind_seeds:
-                idlc = DLCInstance(options=options)
-                idlc.URef = ws
-                idlc.RandSeed1 = seed
-                idlc.wind_heading = wind_heading[i_WiH]
-                idlc.wave_height = wave_Hs[i_Hs]
-                idlc.wave_period = wave_Tp[i_Tp]
-                idlc.wave_gamma = wave_gamma[i_WG]
-                idlc.wave_heading = wave_heading[i_WaH]
-                idlc.probability = probabilities[i_WaH]
-                idlc.turbulent_wind = True
-                idlc.label = '1.2'
-                if options['analysis_time'] > 0:
-                    idlc.analysis_time = options['analysis_time']
-                if options['transient_time'] > 0:
-                    idlc.transient_time = options['transient_time']
-                idlc.PSF = 1.
-                self.cases.append(idlc)
-                if len(wind_heading)>1:
-                    i_WiH+=1
-                if len(wave_Hs)>1:
-                    i_Hs+=1
-                if len(wave_Tp)>1:
-                    i_Tp+=1
-                if len(wave_gamma)>1:
-                    i_WG+=1
-                if len(wave_heading)>1:
-                    i_WaH+=1
+            idlc = DLCInstance(options=options)
+            idlc.URef = ws
+            idlc.RandSeed1 = wind_seeds[i_WiSe]
+            idlc.wind_heading = wind_heading[i_WiH]
+            idlc.wave_height = wave_Hs[i_Hs]
+            idlc.wave_period = wave_Tp[i_Tp]
+            idlc.wave_gamma = wave_gamma[i_WG]
+            idlc.wave_heading = wave_heading[i_WaH]
+            idlc.probability = probabilities[i_WaH]
+            idlc.turbulent_wind = True
+            idlc.label = '1.2'
+            if options['analysis_time'] > 0:
+                idlc.analysis_time = options['analysis_time']
+            if options['transient_time'] > 0:
+                idlc.transient_time = options['transient_time']
+            idlc.PSF = 1.
+            self.cases.append(idlc)
+            if len(wind_seeds)>1:
+                i_WiSe+=1
+            if len(wind_heading)>1:
+                i_WiH+=1
+            if len(wave_Hs)>1:
+                i_Hs+=1
+            if len(wave_Tp)>1:
+                i_Tp+=1
+            if len(wave_gamma)>1:
+                i_WG+=1
+            if len(wave_heading)>1:
+                i_WaH+=1
     
     def generate_1p3(self, options):
         # Power production extreme turbulence model - ultimate loads
         wind_speeds, wind_seeds, wind_heading, wave_Hs, wave_Tp, wave_gamma, wave_heading, _ = self.get_metocean(options)
+        # Counter for wind seed
+        i_WiSe=0
         # Counters for wave conditions
         i_Hs=0
         i_Tp=0
@@ -261,33 +271,34 @@ class DLCGenerator(object):
         i_WG=0
         i_WaH=0
         for ws in wind_speeds:
-            for seed in wind_seeds:
-                idlc = DLCInstance(options=options)
-                idlc.URef = ws
-                idlc.RandSeed1 = seed
-                idlc.wind_heading = wind_heading[i_WiH]
-                idlc.wave_height = wave_Hs[i_Hs]
-                idlc.wave_period = wave_Tp[i_Tp]
-                idlc.wave_gamma = wave_gamma[i_WG]
-                idlc.wave_heading = wave_heading[i_WaH]
-                idlc.IEC_WindType = self.wind_speed_class_num + 'ETM'
-                idlc.turbulent_wind = True
-                idlc.label = '1.3'
-                if options['analysis_time'] > 0:
-                    idlc.analysis_time = options['analysis_time']
-                if options['transient_time'] > 0:
-                    idlc.transient_time = options['transient_time']
-                self.cases.append(idlc)
-                if len(wind_heading)>1:
-                    i_WiH+=1
-                if len(wave_Hs)>1:
-                    i_Hs+=1
-                if len(wave_Tp)>1:
-                    i_Tp+=1
-                if len(wave_gamma)>1:
-                    i_WG+=1
-                if len(wave_heading)>1:
-                    i_WaH+=1
+            idlc = DLCInstance(options=options)
+            idlc.URef = ws
+            idlc.RandSeed1 = wind_seeds[i_WiSe]
+            idlc.wind_heading = wind_heading[i_WiH]
+            idlc.wave_height = wave_Hs[i_Hs]
+            idlc.wave_period = wave_Tp[i_Tp]
+            idlc.wave_gamma = wave_gamma[i_WG]
+            idlc.wave_heading = wave_heading[i_WaH]
+            idlc.IEC_WindType = self.wind_speed_class_num + 'ETM'
+            idlc.turbulent_wind = True
+            idlc.label = '1.3'
+            if options['analysis_time'] > 0:
+                idlc.analysis_time = options['analysis_time']
+            if options['transient_time'] > 0:
+                idlc.transient_time = options['transient_time']
+            self.cases.append(idlc)
+            if len(wind_seeds)>1:
+                i_WiSe+=1
+            if len(wind_heading)>1:
+                i_WiH+=1
+            if len(wave_Hs)>1:
+                i_Hs+=1
+            if len(wave_Tp)>1:
+                i_Tp+=1
+            if len(wave_gamma)>1:
+                i_WG+=1
+            if len(wave_heading)>1:
+                i_WaH+=1
 
     def generate_1p4(self, options):
         # Extreme coherent gust with direction change - ultimate loads
@@ -374,6 +385,8 @@ class DLCGenerator(object):
     def generate_1p6(self, options):
         # Power production normal turbulence model - severe sea state
         wind_speeds, wind_seeds, wind_heading, wave_Hs, wave_Tp, wave_gamma, wave_heading, _ = self.get_metocean(options)
+        # Counter for wind seed
+        i_WiSe=0
         # Counters for wave conditions
         i_Hs=0
         i_Tp=0
@@ -381,40 +394,43 @@ class DLCGenerator(object):
         i_WG=0
         i_WaH=0
         for ws in wind_speeds:
-            for seed in wind_seeds:
-                idlc = DLCInstance(options=options)
-                idlc.URef = ws
-                idlc.RandSeed1 = seed
-                idlc.wind_heading = wind_heading[i_WiH]
-                idlc.wave_height = wave_Hs[i_Hs]
-                idlc.wave_period = wave_Tp[i_Tp]
-                idlc.wave_gamma = wave_gamma[i_WG]
-                idlc.wave_heading = wave_heading[i_WaH]
-                idlc.turbulent_wind = True
-                idlc.label = '1.6'
-                if options['analysis_time'] > 0:
-                    idlc.analysis_time = options['analysis_time']
-                else:
-                    idlc.analysis_time = 3600.
-                if options['transient_time'] > 0:
-                    idlc.transient_time = options['transient_time']
-                self.cases.append(idlc)
-                if len(wind_heading)>1:
-                    i_WiH+=1
-                if len(wave_Hs)>1:
-                    i_Hs+=1
-                if len(wave_Tp)>1:
-                    i_Tp+=1
-                if len(wave_gamma)>1:
-                    i_WG+=1
-                if len(wave_heading)>1:
-                    i_WaH+=1
+            idlc = DLCInstance(options=options)
+            idlc.URef = ws
+            idlc.RandSeed1 = wind_seeds[i_WiSe]
+            idlc.wind_heading = wind_heading[i_WiH]
+            idlc.wave_height = wave_Hs[i_Hs]
+            idlc.wave_period = wave_Tp[i_Tp]
+            idlc.wave_gamma = wave_gamma[i_WG]
+            idlc.wave_heading = wave_heading[i_WaH]
+            idlc.turbulent_wind = True
+            idlc.label = '1.6'
+            if options['analysis_time'] > 0:
+                idlc.analysis_time = options['analysis_time']
+            else:
+                idlc.analysis_time = 3600.
+            if options['transient_time'] > 0:
+                idlc.transient_time = options['transient_time']
+            self.cases.append(idlc)
+            if len(wind_seeds)>1:
+                i_WiSe+=1
+            if len(wind_heading)>1:
+                i_WiH+=1
+            if len(wave_Hs)>1:
+                i_Hs+=1
+            if len(wave_Tp)>1:
+                i_Tp+=1
+            if len(wave_gamma)>1:
+                i_WG+=1
+            if len(wave_heading)>1:
+                i_WaH+=1
 
     def generate_6p1(self, options):
         # Parked (standing still or idling) - extreme wind model 50-year return period - ultimate loads
             
         _, wind_seeds, wind_heading, wave_Hs, wave_Tp, wave_gamma, wave_heading, _ = self.get_metocean(options)
         yaw_misalign_deg = np.array([-8., 8.])
+        # Counter for wind seed
+        i_WiSe=0
         # Counters for wave conditions
         i_Hs=0
         i_Tp=0
@@ -422,42 +438,45 @@ class DLCGenerator(object):
         i_WG=0
         i_WaH=0
         for yaw_ms in yaw_misalign_deg:
-            for seed in wind_seeds:
-                idlc = DLCInstance(options=options)
-                idlc.URef = self.V_e50
-                idlc.yaw_misalign = yaw_ms
-                idlc.RandSeed1 = seed
-                idlc.wind_heading = wind_heading[i_WiH]
-                idlc.wave_height = wave_Hs[i_Hs]
-                idlc.wave_period = wave_Tp[i_Tp]
-                idlc.wave_gamma = wave_gamma[i_WG]
-                idlc.wave_heading = wave_heading[i_WaH]
-                idlc.IEC_WindType = self.wind_speed_class_num + 'EWM50'
-                idlc.turbulent_wind = True
-                if idlc.turbine_status == 'operating':
-                    idlc.turbine_status = 'parked-still'
-                idlc.label = '6.1'
-                if options['analysis_time'] > 0:
-                    idlc.analysis_time = options['analysis_time']
-                if options['transient_time'] > 0:
-                    idlc.transient_time = options['transient_time']
-                self.cases.append(idlc)
-                if len(wind_heading)>1:
-                    i_WiH+=1
-                if len(wave_Hs)>1:
-                    i_Hs+=1
-                if len(wave_Tp)>1:
-                    i_Tp+=1
-                if len(wave_gamma)>1:
-                    i_WG+=1
-                if len(wave_heading)>1:
-                    i_WaH+=1
+            idlc = DLCInstance(options=options)
+            idlc.URef = self.V_e50
+            idlc.yaw_misalign = yaw_ms
+            idlc.RandSeed1 = wind_seeds[i_WiSe]
+            idlc.wind_heading = wind_heading[i_WiH]
+            idlc.wave_height = wave_Hs[i_Hs]
+            idlc.wave_period = wave_Tp[i_Tp]
+            idlc.wave_gamma = wave_gamma[i_WG]
+            idlc.wave_heading = wave_heading[i_WaH]
+            idlc.IEC_WindType = self.wind_speed_class_num + 'EWM50'
+            idlc.turbulent_wind = True
+            if idlc.turbine_status == 'operating':
+                idlc.turbine_status = 'parked-still'
+            idlc.label = '6.1'
+            if options['analysis_time'] > 0:
+                idlc.analysis_time = options['analysis_time']
+            if options['transient_time'] > 0:
+                idlc.transient_time = options['transient_time']
+            self.cases.append(idlc)
+            if len(wind_seeds)>1:
+                i_WiSe+=1
+            if len(wind_heading)>1:
+                i_WiH+=1
+            if len(wave_Hs)>1:
+                i_Hs+=1
+            if len(wave_Tp)>1:
+                i_Tp+=1
+            if len(wave_gamma)>1:
+                i_WG+=1
+            if len(wave_heading)>1:
+                i_WaH+=1
 
     def generate_6p3(self, options):
         # Parked (standing still or idling) - extreme wind model 1-year return period - ultimate loads
 
         _, wind_seeds, wind_heading, wave_Hs, wave_Tp, wave_gamma, wave_heading, _ = self.get_metocean(options)
         yaw_misalign_deg = np.array([-20., 20.])
+        # Counter for wind seed
+        i_WiSe=0
         # Counters for wave conditions
         i_Hs=0
         i_Tp=0
@@ -465,43 +484,47 @@ class DLCGenerator(object):
         i_WG=0
         i_WaH=0
         for yaw_ms in yaw_misalign_deg:
-            for seed in wind_seeds:
-                idlc = DLCInstance(options=options)
-                idlc.URef = self.V_e1
-                idlc.yaw_misalign = yaw_ms
-                idlc.RandSeed1 = seed
-                idlc.wind_heading = wind_heading[i_WiH]
-                idlc.wave_height = wave_Hs[i_Hs]
-                idlc.wave_period = wave_Tp[i_Tp]
-                idlc.wave_gamma = wave_gamma[i_WG]
-                idlc.wave_heading = wave_heading[i_WaH]
-                idlc.IEC_WindType = self.wind_speed_class_num + 'EWM1'
-                idlc.turbulent_wind = True
-                if idlc.turbine_status == 'operating':
-                    idlc.turbine_status = 'parked-still'
-                idlc.label = '6.3'
-                if options['analysis_time'] > 0:
-                    idlc.analysis_time = options['analysis_time']
-                if options['transient_time'] > 0:
-                    idlc.transient_time = options['transient_time']
-                self.cases.append(idlc)
-                if len(wind_heading)>1:
-                    i_WiH+=1
-                if len(wave_Hs)>1:
-                    i_Hs+=1
-                if len(wave_Tp)>1:
-                    i_Tp+=1
-                if len(wave_gamma)>1:
-                    i_WG+=1
-                if len(wave_heading)>1:
-                    i_WaH+=1
+            idlc = DLCInstance(options=options)
+            idlc.URef = self.V_e1
+            idlc.yaw_misalign = yaw_ms
+            idlc.RandSeed1 = wind_seeds[i_WiSe]
+            idlc.wind_heading = wind_heading[i_WiH]
+            idlc.wave_height = wave_Hs[i_Hs]
+            idlc.wave_period = wave_Tp[i_Tp]
+            idlc.wave_gamma = wave_gamma[i_WG]
+            idlc.wave_heading = wave_heading[i_WaH]
+            idlc.IEC_WindType = self.wind_speed_class_num + 'EWM1'
+            idlc.turbulent_wind = True
+            if idlc.turbine_status == 'operating':
+                idlc.turbine_status = 'parked-still'
+            idlc.label = '6.3'
+            if options['analysis_time'] > 0:
+                idlc.analysis_time = options['analysis_time']
+            if options['transient_time'] > 0:
+                idlc.transient_time = options['transient_time']
+            self.cases.append(idlc)
+            if len(wind_seeds)>1:
+                i_WiSe+=1
+            if len(wind_heading)>1:
+                i_WiH+=1
+            if len(wave_Hs)>1:
+                i_Hs+=1
+            if len(wave_Tp)>1:
+                i_Tp+=1
+            if len(wave_gamma)>1:
+                i_WG+=1
+            if len(wave_heading)>1:
+                i_WaH+=1
 
     def generate_6p4(self, options):
         # Parked (standing still or idling) - normal turbulence model - fatigue loads
-        wind_speeds, wind_seeds, wind_heading, wave_Hs, wave_Tp, wave_gamma, wave_heading, _ = self.get_metocean(options)
         wind_speeds = np.arange(self.ws_cut_in, 0.7 * self.V_ref, options['ws_bin_size'])
         if wind_speeds[-1] != self.V_ref:
             wind_speeds = np.append(wind_speeds, self.V_ref)
+        wind_seeds = self.get_wind_seeds(options, len(wind_speeds))
+        _, _, wind_heading, wave_Hs, wave_Tp, wave_gamma, wave_heading, _ = self.get_metocean(options)
+        # Counter for wind seed
+        i_WiSe=0
         # Counters for wave conditions
         i_Hs=0
         i_Tp=0
@@ -509,34 +532,35 @@ class DLCGenerator(object):
         i_WG=0
         i_WaH=0
         for ws in wind_speeds:
-            for seed in wind_seeds:
-                idlc = DLCInstance(options=options)
-                idlc.URef = ws
-                idlc.RandSeed1 = seed
-                idlc.wind_heading = wind_heading[i_WiH]
-                idlc.wave_height = wave_Hs[i_Hs]
-                idlc.wave_period = wave_Tp[i_Tp]
-                idlc.wave_gamma = wave_gamma[i_WG]
-                idlc.wave_heading = wave_heading[i_WaH]
-                idlc.turbulent_wind = True
-                if idlc.turbine_status == 'operating':
-                    idlc.turbine_status = 'parked-still'
-                idlc.label = '6.4'
-                if options['analysis_time'] > 0:
-                    idlc.analysis_time = options['analysis_time']
-                if options['transient_time'] > 0:
-                    idlc.transient_time = options['transient_time']
-                self.cases.append(idlc)
-                if len(wind_heading)>1:
-                    i_WiH+=1
-                if len(wave_Hs)>1:
-                    i_Hs+=1
-                if len(wave_Tp)>1:
-                    i_Tp+=1
-                if len(wave_gamma)>1:
-                    i_WG+=1
-                if len(wave_heading)>1:
-                    i_WaH+=1
+            idlc = DLCInstance(options=options)
+            idlc.URef = ws
+            idlc.RandSeed1 = wind_seeds[i_WiSe]
+            idlc.wind_heading = wind_heading[i_WiH]
+            idlc.wave_height = wave_Hs[i_Hs]
+            idlc.wave_period = wave_Tp[i_Tp]
+            idlc.wave_gamma = wave_gamma[i_WG]
+            idlc.wave_heading = wave_heading[i_WaH]
+            idlc.turbulent_wind = True
+            if idlc.turbine_status == 'operating':
+                idlc.turbine_status = 'parked-still'
+            idlc.label = '6.4'
+            if options['analysis_time'] > 0:
+                idlc.analysis_time = options['analysis_time']
+            if options['transient_time'] > 0:
+                idlc.transient_time = options['transient_time']
+            self.cases.append(idlc)
+            if len(wind_seeds)>1:
+                i_WiSe+=1
+            if len(wind_heading)>1:
+                i_WiH+=1
+            if len(wave_Hs)>1:
+                i_Hs+=1
+            if len(wave_Tp)>1:
+                i_Tp+=1
+            if len(wave_gamma)>1:
+                i_WG+=1
+            if len(wave_heading)>1:
+                i_WaH+=1
 
 
 if __name__ == "__main__":

--- a/weis/dlc_driver/dlc_generator.py
+++ b/weis/dlc_driver/dlc_generator.py
@@ -40,14 +40,17 @@ class DLCInstance(object):
         
 class DLCGenerator(object):
 
-    def __init__(self, ws_cut_in=4.0, ws_cut_out=25.0, ws_rated=10.0, wind_speed_class = 'I', wind_turbulence_class = 'B'):
+    def __init__(self, ws_cut_in=4.0, ws_cut_out=25.0, ws_rated=10.0, wind_speed_class = 'I', wind_turbulence_class = 'B', fix_wind_seeds=True):
         self.ws_cut_in = ws_cut_in
         self.ws_cut_out = ws_cut_out
         self.wind_speed_class = wind_speed_class
         self.wind_turbulence_class = wind_turbulence_class
         self.ws_rated = ws_rated
         self.cases = []
-        self.rng = np.random.default_rng()
+        if fix_wind_seeds:
+            self.rng = np.random.default_rng(12345)
+        else:
+            self.rng = np.random.default_rng()
         self.n_cases = 0
     
     def IECwind(self):
@@ -581,7 +584,8 @@ if __name__ == "__main__":
     DLCs = modeling_options['DLC_driver']['DLCs']
     
     # Initialize the generator
-    dlc_generator = DLCGenerator(ws_cut_in, ws_cut_out, ws_rated, wind_speed_class, wind_turbulence_class)
+    fix_wind_seeds = modeling_options['DLC_driver']['fix_wind_seeds']
+    dlc_generator = DLCGenerator(ws_cut_in, ws_cut_out, ws_rated, wind_speed_class, wind_turbulence_class, fix_wind_seeds)
 
     # Generate cases from user inputs
     for i_DLC in range(len(DLCs)):

--- a/weis/dlc_driver/test/test_DLC_generator.py
+++ b/weis/dlc_driver/test/test_DLC_generator.py
@@ -30,9 +30,9 @@ class TestIECWind(unittest.TestCase):
             DLCopt = DLCs[i_DLC]
             dlc_generator.generate(DLCopt['DLC'], DLCopt)
 
-        np.testing.assert_equal(dlc_generator.cases[5].URef, cut_out)
-        np.testing.assert_equal(dlc_generator.n_cases_dlc11, 6)
-        np.testing.assert_equal(dlc_generator.n_cases, 47)
+        np.testing.assert_equal(dlc_generator.cases[11].URef, cut_out)
+        np.testing.assert_equal(dlc_generator.n_cases_dlc11, 12)
+        np.testing.assert_equal(dlc_generator.n_cases, 53)
 
 if __name__ == "__main__":
     unittest.main()

--- a/weis/dlc_driver/test/test_DLC_generator.py
+++ b/weis/dlc_driver/test/test_DLC_generator.py
@@ -32,7 +32,6 @@ class TestIECWind(unittest.TestCase):
 
         np.testing.assert_equal(dlc_generator.cases[5].URef, cut_out)
         np.testing.assert_equal(dlc_generator.n_cases_dlc11, 6)
-        print(len(dlc_generator.cases))
         np.testing.assert_equal(dlc_generator.n_cases, 47)
 
 if __name__ == "__main__":

--- a/weis/dlc_driver/test/test_DLC_generator.py
+++ b/weis/dlc_driver/test/test_DLC_generator.py
@@ -31,7 +31,7 @@ class TestIECWind(unittest.TestCase):
             dlc_generator.generate(DLCopt['DLC'], DLCopt)
 
         np.testing.assert_equal(dlc_generator.cases[11].URef, cut_out)
-        np.testing.assert_equal(dlc_generator.n_cases_dlc11, 12)
+        np.testing.assert_equal(dlc_generator.n_ws_dlc11, 6)
         np.testing.assert_equal(dlc_generator.n_cases, 53)
 
 if __name__ == "__main__":

--- a/weis/frequency/raft_wrapper.py
+++ b/weis/frequency/raft_wrapper.py
@@ -280,7 +280,8 @@ class RAFT_WEIS_Prep(om.ExplicitComponent):
         rated = inputs['Vrated']
         ws_class = discrete_inputs['turbine_class']
         turb_class = discrete_inputs['turbulence_class']
-        dlc_generator = DLCGenerator(cut_in, cut_out, rated, ws_class, turb_class)
+        fix_wind_seeds = opt['DLC_driver']['fix_wind_seeds']
+        dlc_generator = DLCGenerator(cut_in, cut_out, rated, ws_class, turb_class, fix_wind_seeds)
         # Generate cases from user inputs
         for i_DLC in range(len(DLCs)):
             DLCopt = DLCs[i_DLC]

--- a/weis/glue_code/gc_LoadInputs.py
+++ b/weis/glue_code/gc_LoadInputs.py
@@ -111,7 +111,7 @@ class WindTurbineOntologyPythonWEIS(WindTurbineOntologyPython):
             DLCopt = DLCs[i_DLC]
             dlc_generator.generate(DLCopt['DLC'], DLCopt)
         self.modeling_options['DLC_driver']['n_cases'] = dlc_generator.n_cases
-        self.modeling_options['DLC_driver']['n_cases_dlc11'] = dlc_generator.n_cases_dlc11
+        self.modeling_options['DLC_driver']['n_ws_dlc11'] = dlc_generator.n_ws_dlc11
 
 
     def set_openmdao_vectors_control(self):

--- a/weis/inputs/modeling_schema.yaml
+++ b/weis/inputs/modeling_schema.yaml
@@ -3129,7 +3129,10 @@ properties:
                                     maximum: 1.e+3
                                     unit: s
                                     description: Minimum start time for coherent structures in RootName.cts
-
+            fix_wind_seeds:
+                type: boolean
+                default: True
+                description: Fix the seed of the random integer generator controlling the seed of TurbSim. When set to False, the seeds change everytime the DLC generator class is called. It is recommended to keep it to True when the optimization is on, or different wind seeds will be generated for every function call, complicating the smoothness of the solution space. Even when set to True, the wind seeds are different across wind speeds and DLCs.
 
     ROSCO:
         type: object

--- a/weis/inputs/modeling_schema.yaml
+++ b/weis/inputs/modeling_schema.yaml
@@ -2753,7 +2753,7 @@ properties:
                             description: Number of turbulent wind seeds
                         wind_seed:
                             type: array
-                            default: [0]
+                            default: []
                             description: Turbulent wind random number generator seeds
                             items:
                                 type: integer


### PR DESCRIPTION
Wind turbulent seeds are no longer constant across wind speeds. There is also a flag, set to True as default, that fixes the seed behind the turbulent seed generator. This way the same seeds are used for every function evaluation.

## Purpose
Better handle the wind seeds

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation