### PR TITLE
MPI for Linearization (example 12)

### DIFF
--- a/examples/12_linearization/modeling_options.yaml
+++ b/examples/12_linearization/modeling_options.yaml
@@ -37,7 +37,7 @@ Level3: # Options for WEIS fidelity level 3 = nonlinear time domain
     flag: False
     OutFileFmt: 3
     simulation:
-        TMax: 1.
+        TMax: 2000.0
         DT: 0.01
         CompElast: 1
         CompInflow: 1
@@ -97,15 +97,15 @@ Level2:
     flag: True
     simulation:         # could these be included in openfast options?
         flag: True
-        TMax: 10.      # run simulations using IEC standards, could share that info
+        TMax: 600.      # run simulations using IEC standards, could share that info
     linearization:
-        TMax: 60.
+        TMax: 2000.
         DT: 0.01
         TrimGain: 1e-3
         TrimTol: 1e-2
-        wind_speeds: [8.]
+        wind_speeds: [4., 6., 8., 10., 12., 14., 16.]
         DOFs: ['GenDOF','TwFADOF1','PtfmPDOF']
-        NLinTimes: 1
+        NLinTimes: 12
 
 DLC_driver:
     openfast_file_management:

--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -560,7 +560,10 @@ class FASTLoadCases(ExplicitComponent):
 
                     # This is going to use the last discon_in file of the linearization set as the simulation file
                     # Currently fine because openfast is executed (or not executed if overwrite=False) after the file writing
-                    discon_in_file = os.path.join(self.FAST_runDirectory, self.fst_vt['ServoDyn']['DLL_InFile'])
+                    if 'DLL_InFile' in self.fst_vt['ServoDyn']:     # if using file inputs
+                        discon_in_file = os.path.join(self.FAST_runDirectory, self.fst_vt['ServoDyn']['DLL_InFile'])
+                    else:       # if using fst_vt inputs from openfast_openmdao
+                        discon_in_file = os.path.join(self.FAST_runDirectory, self.lin_case_name[0] + '_DISCON.IN')
 
                     lib_name = os.path.join(os.path.dirname(os.path.realpath(__file__)),'../../local/lib/libdiscon'+lib_ext)
 


### PR DESCRIPTION
## Purpose
Linearization capability was originally incompatible with WEIS MPI parallelization. This PR modifies the runWEIS and openfast_openmdao logics to have linearization capability working with WEIS MPI parallelization.

This PR does not break anything else. However, the current status (even before this PR) still have problem in postprocessing stage where DEL is calculated. This PR did not fix that bug, so it is only working up to linearization and saving linear model to ABCD_matrices.pkl.

## Type of change
What types of change is it?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Tested with example 12 with required modification, e.g., TMax increased, NLinTimes=12, Multiple wind speeds.

## Checklist

- [X] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation