### PR TITLE
do not write ontology if from openfast true

### DIFF
--- a/weis/glue_code/runWEIS.py
+++ b/weis/glue_code/runWEIS.py
@@ -199,7 +199,8 @@ def run_weis(fname_wt_input, fname_modeling_options, fname_opt_options, overridd
             froot_out = os.path.join(folder_output, opt_options['general']['fname_output'])
             # Remove the fst_vt key from the dictionary and write out the modeling options
             modeling_options['General']['openfast_configuration']['fst_vt'] = {}
-            wt_initial.write_ontology(wt_opt, froot_out)
+            if not modeling_options['Level3']['from_openfast']:
+                wt_initial.write_ontology(wt_opt, froot_out)
             wt_initial.write_options(froot_out)
             
             # Save data to numpy and matlab arrays


### PR DESCRIPTION
Quick bug fix to skip saving out the ontology if the loading is done from openfast 

## Purpose
Run DLCs on a given openfast model

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation