### PR TITLE
Yaw inertias for fixed-bottom

### DIFF
--- a/examples/06_IEA-15-240-RWT/modeling_options.yaml
+++ b/examples/06_IEA-15-240-RWT/modeling_options.yaml
@@ -60,7 +60,7 @@ Level3: # Options for WEIS fidelity level 3 = nonlinear time domain
         TeetDOF: False
         DrTrDOF: False 
         GenDOF: True
-        YawDOF: False  
+        YawDOF: True  
         TwFADOF1 : True
         TwFADOF2 : True
         TwSSDOF1 : True

--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -919,7 +919,7 @@ class FASTLoadCases(ExplicitComponent):
             fst_vt['ElastoDyn']['PtfmRIner'] = 0.
             fst_vt['ElastoDyn']['PtfmPIner'] = 0.
             # Advice from R. Bergua- Use a dummy quantity (at least 1e4) here when have fixed-bottom support
-            fst_vt['ElastoDyn']['PtfmYIner'] = 1e5 if modopt['flags']['offshore'] else 0.0
+            fst_vt['ElastoDyn']['PtfmYIner'] = 1e8 if modopt['flags']['offshore'] else 0.0
             fst_vt['ElastoDyn']['PtfmCMxt'] = 0.
             fst_vt['ElastoDyn']['PtfmCMyt'] = 0.
             fst_vt['ElastoDyn']['PtfmCMzt'] = float(inputs['tower_base_height'])

--- a/weis/glue_code/glue_code.py
+++ b/weis/glue_code/glue_code.py
@@ -436,6 +436,7 @@ class WindPark(om.Group):
                     self.connect('tower.cd',                        'aeroelastic.tower_cd')
                     self.connect('tower_grid.height',               'aeroelastic.tower_height')
                     self.connect('tower_grid.foundation_height',    'aeroelastic.tower_base_height')
+                    self.connect('towerse.tower_I_base',            'aeroelastic.tower_I_base')
                     if modeling_options["flags"]["monopile"] or modeling_options["flags"]["jacket"]:
                         self.connect('fixedse.torsion_freqs',      'aeroelastic.tor_freq', src_indices=[0])
                         self.connect('fixedse.tower_fore_aft_modes',     'aeroelastic.fore_aft_modes')


### PR DESCRIPTION
## Purpose
Fix error in zero-value for PtfmYIner when doing fixed-bottom and improve value for NacYIner per Roger Bergua's advice.

Roger recommends a dummy value (at least 1e4) for PtfmYIner and adding 1/3 of the tower yaw inertia to the NacYIner value as an activated lumped modal mass.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation