### PR TITLE
minor bug fixes: runFAST_pywrapper.py & FAST_writer.py

### DIFF
--- a/weis/aeroelasticse/FAST_writer.py
+++ b/weis/aeroelasticse/FAST_writer.py
@@ -859,7 +859,7 @@ class InputWriter_OpenFAST(object):
             f.write('! ------------------------------------------------------------------------------\n')
             f.write('{:<22}   {:<11} {:}'.format(self.fst_vt['AeroDyn15']['af_data'][afi][0]['InterpOrd'], 'InterpOrd', '! Interpolation order to use for quasi-steady table lookup {1=linear; 3=cubic spline; "default"} [default=3]\n'))
             f.write('{:<22}   {:<11} {:}'.format(self.fst_vt['AeroDyn15']['af_data'][afi][0]['NonDimArea'], 'NonDimArea', '! The non-dimensional area of the airfoil (area/chord^2) (set to 1.0 if unsure or unneeded)\n'))
-            if self.fst_vt['AeroDyn15']['af_data'][1][0]['NumCoords'] != '0':
+            if self.fst_vt['AeroDyn15']['af_data'][afi][0]['NumCoords'] != '0':
                 f.write('@"{:}_AF{:02d}_Coords.txt"       {:<11} {:}'.format(self.FAST_namingOut, afi, 'NumCoords', '! The number of coordinates in the airfoil shape file. Set to zero if coordinates not included.\n'))
             else:
                 f.write('{:<22d}       {:<11} {:}'.format(0, 'NumCoords', '! The number of coordinates in the airfoil shape file. Set to zero if coordinates not included.\n'))

--- a/weis/aeroelasticse/runFAST_pywrapper.py
+++ b/weis/aeroelasticse/runFAST_pywrapper.py
@@ -229,7 +229,7 @@ class runFAST_pywrapper(object):
                 if os.path.exists(FAST_Output):
                     output_init = OpenFASTBinary(FAST_Output, magnitude_channels=self.magnitude_channels)
                 elif os.path.exists(FAST_Output_txt):
-                    output_init = OpenFASTAscii(FAST_Output, magnitude_channels=self.magnitude_channels)
+                    output_init = OpenFASTAscii(FAST_Output_txt, magnitude_channels=self.magnitude_channels)
                     
                 output_init.read()
 


### PR DESCRIPTION

## Purpose
Minor bug fixes:

- When writing Airfoil coordinates, the 2nd airfoil was being used in all iterations. Running with a single airfoil blade throws an `index out-of-bound` error.
- When reading OpenFAST output, the binary output file name was passed to `OpenFASTAscii`.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Not covered in the current test suite.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation