### PR TITLE
Rel path outputs

### DIFF
--- a/weis/glue_code/runWEIS.py
+++ b/weis/glue_code/runWEIS.py
@@ -67,10 +67,6 @@ def run_weis(fname_wt_input, fname_modeling_options, fname_opt_options,
         color_i = 0
         rank = 0
 
-    # make the folder_output relative to the input, if it's a relative path
-    analysis_input_dir = os.path.dirname(opt_options['fname_input_analysis'])
-    opt_options['general']['folder_output'] = os.path.join(analysis_input_dir,opt_options['general']['folder_output'])
-
     folder_output = opt_options['general']['folder_output']
     if rank == 0 and not os.path.isdir(folder_output):
         os.makedirs(folder_output,exist_ok=True)

--- a/weis/inputs/analysis_schema.yaml
+++ b/weis/inputs/analysis_schema.yaml
@@ -11,7 +11,7 @@ properties:
             folder_output:
                 type: string
                 default: output
-                description: Name of folder to dump output files
+                description: Name of folder to dump output files. The path can be absolute or relative. When a relative path is defined, the path starts from folder where WEIS is run.
             fname_output:
                 type: string
                 default: output


### PR DESCRIPTION
## Purpose
When a relative path is provided in the analysis options for the output folder, the path starts from running directory, not where analysis options is located. This commit aligns WEIS to WISDEM, see https://github.com/WISDEM/WISDEM/blob/e0def101837ce0d677649846545ebdbc65ee433f/wisdem/glue_code/runWISDEM.py#L37. The need for this commit arose in an industrial collaboration where the partner runs WEIS on a HPC with no folder writing access

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation