### PR TITLE
force DTBeam to be set to default

### DIFF
--- a/weis/aeroelasticse/openmdao_openfast.py
+++ b/weis/aeroelasticse/openmdao_openfast.py
@@ -1126,6 +1126,7 @@ class FASTLoadCases(ExplicitComponent):
             fst_vt['ElastoDynBlade']['BldEdgSh'][i] = inputs['blade:edge_mode_shapes'][0,i] / sum(inputs['blade:edge_mode_shapes'][0,:])
 
         # Update BeamDyn Main
+        fst_vt['BeamDyn']['DTBeam'] = "Default"
         fst_vt['BeamDyn']['member_total'] = 1
         fst_vt['BeamDyn']['kp_total'] = len(inputs['ref_axis_blade'][:,0])
         fst_vt['BeamDyn']['members'] = [{}]


### PR DESCRIPTION
Fix small but important bug that prevented WEIS to run with BeamDyn unless the user had set DTBeam among their modeling options